### PR TITLE
유저간 거래 기능

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,7 @@ class MyApp extends StatelessWidget {
           }
 
           // 로그인 여부에 따라 초기 화면을 다르게 설정
-          if (snapshot.data == 'user') {
+          if (snapshot.data == 'users') {
             // 만약 email이 저장되어 있으면 user-home으로 이동
             return UserHomeScreen();
           } else if (snapshot.data == 'owner') {

--- a/lib/model/user_model.dart
+++ b/lib/model/user_model.dart
@@ -11,6 +11,7 @@ class User with _$User {
     required String email,
     required int points,
     required String authType,
+    String? profilePicUrl,
     String? pubId,
   }) = _User;
 

--- a/lib/model/user_model.freezed.dart
+++ b/lib/model/user_model.freezed.dart
@@ -25,6 +25,7 @@ mixin _$User {
   String get email => throw _privateConstructorUsedError;
   int get points => throw _privateConstructorUsedError;
   String get authType => throw _privateConstructorUsedError;
+  String? get profilePicUrl => throw _privateConstructorUsedError;
   String? get pubId => throw _privateConstructorUsedError;
 
   /// Serializes this User to a JSON map.
@@ -47,6 +48,7 @@ abstract class $UserCopyWith<$Res> {
       String email,
       int points,
       String authType,
+      String? profilePicUrl,
       String? pubId});
 }
 
@@ -70,6 +72,7 @@ class _$UserCopyWithImpl<$Res, $Val extends User>
     Object? email = null,
     Object? points = null,
     Object? authType = null,
+    Object? profilePicUrl = freezed,
     Object? pubId = freezed,
   }) {
     return _then(_value.copyWith(
@@ -93,6 +96,10 @@ class _$UserCopyWithImpl<$Res, $Val extends User>
           ? _value.authType
           : authType // ignore: cast_nullable_to_non_nullable
               as String,
+      profilePicUrl: freezed == profilePicUrl
+          ? _value.profilePicUrl
+          : profilePicUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
       pubId: freezed == pubId
           ? _value.pubId
           : pubId // ignore: cast_nullable_to_non_nullable
@@ -114,6 +121,7 @@ abstract class _$$UserImplCopyWith<$Res> implements $UserCopyWith<$Res> {
       String email,
       int points,
       String authType,
+      String? profilePicUrl,
       String? pubId});
 }
 
@@ -134,6 +142,7 @@ class __$$UserImplCopyWithImpl<$Res>
     Object? email = null,
     Object? points = null,
     Object? authType = null,
+    Object? profilePicUrl = freezed,
     Object? pubId = freezed,
   }) {
     return _then(_$UserImpl(
@@ -157,6 +166,10 @@ class __$$UserImplCopyWithImpl<$Res>
           ? _value.authType
           : authType // ignore: cast_nullable_to_non_nullable
               as String,
+      profilePicUrl: freezed == profilePicUrl
+          ? _value.profilePicUrl
+          : profilePicUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
       pubId: freezed == pubId
           ? _value.pubId
           : pubId // ignore: cast_nullable_to_non_nullable
@@ -174,6 +187,7 @@ class _$UserImpl implements _User {
       required this.email,
       required this.points,
       required this.authType,
+      this.profilePicUrl,
       this.pubId});
 
   factory _$UserImpl.fromJson(Map<String, dynamic> json) =>
@@ -190,11 +204,13 @@ class _$UserImpl implements _User {
   @override
   final String authType;
   @override
+  final String? profilePicUrl;
+  @override
   final String? pubId;
 
   @override
   String toString() {
-    return 'User(uid: $uid, name: $name, email: $email, points: $points, authType: $authType, pubId: $pubId)';
+    return 'User(uid: $uid, name: $name, email: $email, points: $points, authType: $authType, profilePicUrl: $profilePicUrl, pubId: $pubId)';
   }
 
   @override
@@ -208,13 +224,15 @@ class _$UserImpl implements _User {
             (identical(other.points, points) || other.points == points) &&
             (identical(other.authType, authType) ||
                 other.authType == authType) &&
+            (identical(other.profilePicUrl, profilePicUrl) ||
+                other.profilePicUrl == profilePicUrl) &&
             (identical(other.pubId, pubId) || other.pubId == pubId));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, uid, name, email, points, authType, pubId);
+  int get hashCode => Object.hash(
+      runtimeType, uid, name, email, points, authType, profilePicUrl, pubId);
 
   /// Create a copy of User
   /// with the given fields replaced by the non-null parameter values.
@@ -239,6 +257,7 @@ abstract class _User implements User {
       required final String email,
       required final int points,
       required final String authType,
+      final String? profilePicUrl,
       final String? pubId}) = _$UserImpl;
 
   factory _User.fromJson(Map<String, dynamic> json) = _$UserImpl.fromJson;
@@ -253,6 +272,8 @@ abstract class _User implements User {
   int get points;
   @override
   String get authType;
+  @override
+  String? get profilePicUrl;
   @override
   String? get pubId;
 

--- a/lib/model/user_model.g.dart
+++ b/lib/model/user_model.g.dart
@@ -12,6 +12,7 @@ _$UserImpl _$$UserImplFromJson(Map<String, dynamic> json) => _$UserImpl(
       email: json['email'] as String,
       points: (json['points'] as num).toInt(),
       authType: json['authType'] as String,
+      profilePicUrl: json['profilePicUrl'] as String?,
       pubId: json['pubId'] as String?,
     );
 
@@ -22,5 +23,6 @@ Map<String, dynamic> _$$UserImplToJson(_$UserImpl instance) =>
       'email': instance.email,
       'points': instance.points,
       'authType': instance.authType,
+      'profilePicUrl': instance.profilePicUrl,
       'pubId': instance.pubId,
     };

--- a/lib/model/user_transaction_model.dart
+++ b/lib/model/user_transaction_model.dart
@@ -1,0 +1,30 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_transaction_model.freezed.dart';
+part 'user_transaction_model.g.dart';
+
+@freezed
+class UserTransaction with _$UserTransaction {
+  const factory UserTransaction({
+    required String transactionId,       // 트랜잭션 고유 ID
+    required String senderEmail,         // 보내는 사람 이메일
+    required String receiverEmail,       // 받는 사람 이메일
+    required int amount,              // 거래 금액
+    required DateTime timestamp,         // 거래 발생 시각
+  }) = _UserTransaction;
+
+  // Firestore 데이터와 변환할 때 사용할 JSON 직렬화 메서드
+  factory UserTransaction.fromJson(Map<String, dynamic> json) => _$UserTransactionFromJson(json);
+}
+extension UserTransactionExtensions on UserTransaction {
+  // Firestore에 저장할 때 변환할 Map 형식
+  Map<String, dynamic> toFirestore() {
+    return {
+      'transactionId': transactionId,
+      'senderEmail': senderEmail,
+      'receiverEmail': receiverEmail,
+      'amount': amount,
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+}

--- a/lib/model/user_transaction_model.dart
+++ b/lib/model/user_transaction_model.dart
@@ -7,8 +7,8 @@ part 'user_transaction_model.g.dart';
 class UserTransaction with _$UserTransaction {
   const factory UserTransaction({
     required String transactionId,       // 트랜잭션 고유 ID
-    required String senderEmail,         // 보내는 사람 이메일
-    required String receiverEmail,       // 받는 사람 이메일
+    required String senderUid,         // 보내는 사람 이메일
+    required String receiverUid,       // 받는 사람 이메일
     required int amount,              // 거래 금액
     required DateTime timestamp,         // 거래 발생 시각
   }) = _UserTransaction;
@@ -21,8 +21,8 @@ extension UserTransactionExtensions on UserTransaction {
   Map<String, dynamic> toFirestore() {
     return {
       'transactionId': transactionId,
-      'senderEmail': senderEmail,
-      'receiverEmail': receiverEmail,
+      'senderUid': senderUid,
+      'receiverUid': receiverUid,
       'amount': amount,
       'timestamp': timestamp.toIso8601String(),
     };

--- a/lib/model/user_transaction_model.freezed.dart
+++ b/lib/model/user_transaction_model.freezed.dart
@@ -1,0 +1,258 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_transaction_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+UserTransaction _$UserTransactionFromJson(Map<String, dynamic> json) {
+  return _UserTransaction.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UserTransaction {
+  String get transactionId => throw _privateConstructorUsedError; // 트랜잭션 고유 ID
+  String get senderEmail => throw _privateConstructorUsedError; // 보내는 사람 이메일
+  String get receiverEmail => throw _privateConstructorUsedError; // 받는 사람 이메일
+  int get amount => throw _privateConstructorUsedError; // 거래 금액
+  DateTime get timestamp => throw _privateConstructorUsedError;
+
+  /// Serializes this UserTransaction to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of UserTransaction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $UserTransactionCopyWith<UserTransaction> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserTransactionCopyWith<$Res> {
+  factory $UserTransactionCopyWith(
+          UserTransaction value, $Res Function(UserTransaction) then) =
+      _$UserTransactionCopyWithImpl<$Res, UserTransaction>;
+  @useResult
+  $Res call(
+      {String transactionId,
+      String senderEmail,
+      String receiverEmail,
+      int amount,
+      DateTime timestamp});
+}
+
+/// @nodoc
+class _$UserTransactionCopyWithImpl<$Res, $Val extends UserTransaction>
+    implements $UserTransactionCopyWith<$Res> {
+  _$UserTransactionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of UserTransaction
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transactionId = null,
+    Object? senderEmail = null,
+    Object? receiverEmail = null,
+    Object? amount = null,
+    Object? timestamp = null,
+  }) {
+    return _then(_value.copyWith(
+      transactionId: null == transactionId
+          ? _value.transactionId
+          : transactionId // ignore: cast_nullable_to_non_nullable
+              as String,
+      senderEmail: null == senderEmail
+          ? _value.senderEmail
+          : senderEmail // ignore: cast_nullable_to_non_nullable
+              as String,
+      receiverEmail: null == receiverEmail
+          ? _value.receiverEmail
+          : receiverEmail // ignore: cast_nullable_to_non_nullable
+              as String,
+      amount: null == amount
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      timestamp: null == timestamp
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$UserTransactionImplCopyWith<$Res>
+    implements $UserTransactionCopyWith<$Res> {
+  factory _$$UserTransactionImplCopyWith(_$UserTransactionImpl value,
+          $Res Function(_$UserTransactionImpl) then) =
+      __$$UserTransactionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String transactionId,
+      String senderEmail,
+      String receiverEmail,
+      int amount,
+      DateTime timestamp});
+}
+
+/// @nodoc
+class __$$UserTransactionImplCopyWithImpl<$Res>
+    extends _$UserTransactionCopyWithImpl<$Res, _$UserTransactionImpl>
+    implements _$$UserTransactionImplCopyWith<$Res> {
+  __$$UserTransactionImplCopyWithImpl(
+      _$UserTransactionImpl _value, $Res Function(_$UserTransactionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserTransaction
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transactionId = null,
+    Object? senderEmail = null,
+    Object? receiverEmail = null,
+    Object? amount = null,
+    Object? timestamp = null,
+  }) {
+    return _then(_$UserTransactionImpl(
+      transactionId: null == transactionId
+          ? _value.transactionId
+          : transactionId // ignore: cast_nullable_to_non_nullable
+              as String,
+      senderEmail: null == senderEmail
+          ? _value.senderEmail
+          : senderEmail // ignore: cast_nullable_to_non_nullable
+              as String,
+      receiverEmail: null == receiverEmail
+          ? _value.receiverEmail
+          : receiverEmail // ignore: cast_nullable_to_non_nullable
+              as String,
+      amount: null == amount
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      timestamp: null == timestamp
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$UserTransactionImpl implements _UserTransaction {
+  const _$UserTransactionImpl(
+      {required this.transactionId,
+      required this.senderEmail,
+      required this.receiverEmail,
+      required this.amount,
+      required this.timestamp});
+
+  factory _$UserTransactionImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UserTransactionImplFromJson(json);
+
+  @override
+  final String transactionId;
+// 트랜잭션 고유 ID
+  @override
+  final String senderEmail;
+// 보내는 사람 이메일
+  @override
+  final String receiverEmail;
+// 받는 사람 이메일
+  @override
+  final int amount;
+// 거래 금액
+  @override
+  final DateTime timestamp;
+
+  @override
+  String toString() {
+    return 'UserTransaction(transactionId: $transactionId, senderEmail: $senderEmail, receiverEmail: $receiverEmail, amount: $amount, timestamp: $timestamp)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UserTransactionImpl &&
+            (identical(other.transactionId, transactionId) ||
+                other.transactionId == transactionId) &&
+            (identical(other.senderEmail, senderEmail) ||
+                other.senderEmail == senderEmail) &&
+            (identical(other.receiverEmail, receiverEmail) ||
+                other.receiverEmail == receiverEmail) &&
+            (identical(other.amount, amount) || other.amount == amount) &&
+            (identical(other.timestamp, timestamp) ||
+                other.timestamp == timestamp));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, transactionId, senderEmail,
+      receiverEmail, amount, timestamp);
+
+  /// Create a copy of UserTransaction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UserTransactionImplCopyWith<_$UserTransactionImpl> get copyWith =>
+      __$$UserTransactionImplCopyWithImpl<_$UserTransactionImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$UserTransactionImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _UserTransaction implements UserTransaction {
+  const factory _UserTransaction(
+      {required final String transactionId,
+      required final String senderEmail,
+      required final String receiverEmail,
+      required final int amount,
+      required final DateTime timestamp}) = _$UserTransactionImpl;
+
+  factory _UserTransaction.fromJson(Map<String, dynamic> json) =
+      _$UserTransactionImpl.fromJson;
+
+  @override
+  String get transactionId; // 트랜잭션 고유 ID
+  @override
+  String get senderEmail; // 보내는 사람 이메일
+  @override
+  String get receiverEmail; // 받는 사람 이메일
+  @override
+  int get amount; // 거래 금액
+  @override
+  DateTime get timestamp;
+
+  /// Create a copy of UserTransaction
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$UserTransactionImplCopyWith<_$UserTransactionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/user_transaction_model.freezed.dart
+++ b/lib/model/user_transaction_model.freezed.dart
@@ -21,8 +21,8 @@ UserTransaction _$UserTransactionFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$UserTransaction {
   String get transactionId => throw _privateConstructorUsedError; // 트랜잭션 고유 ID
-  String get senderEmail => throw _privateConstructorUsedError; // 보내는 사람 이메일
-  String get receiverEmail => throw _privateConstructorUsedError; // 받는 사람 이메일
+  String get senderUid => throw _privateConstructorUsedError; // 보내는 사람 이메일
+  String get receiverUid => throw _privateConstructorUsedError; // 받는 사람 이메일
   int get amount => throw _privateConstructorUsedError; // 거래 금액
   DateTime get timestamp => throw _privateConstructorUsedError;
 
@@ -44,8 +44,8 @@ abstract class $UserTransactionCopyWith<$Res> {
   @useResult
   $Res call(
       {String transactionId,
-      String senderEmail,
-      String receiverEmail,
+      String senderUid,
+      String receiverUid,
       int amount,
       DateTime timestamp});
 }
@@ -66,8 +66,8 @@ class _$UserTransactionCopyWithImpl<$Res, $Val extends UserTransaction>
   @override
   $Res call({
     Object? transactionId = null,
-    Object? senderEmail = null,
-    Object? receiverEmail = null,
+    Object? senderUid = null,
+    Object? receiverUid = null,
     Object? amount = null,
     Object? timestamp = null,
   }) {
@@ -76,13 +76,13 @@ class _$UserTransactionCopyWithImpl<$Res, $Val extends UserTransaction>
           ? _value.transactionId
           : transactionId // ignore: cast_nullable_to_non_nullable
               as String,
-      senderEmail: null == senderEmail
-          ? _value.senderEmail
-          : senderEmail // ignore: cast_nullable_to_non_nullable
+      senderUid: null == senderUid
+          ? _value.senderUid
+          : senderUid // ignore: cast_nullable_to_non_nullable
               as String,
-      receiverEmail: null == receiverEmail
-          ? _value.receiverEmail
-          : receiverEmail // ignore: cast_nullable_to_non_nullable
+      receiverUid: null == receiverUid
+          ? _value.receiverUid
+          : receiverUid // ignore: cast_nullable_to_non_nullable
               as String,
       amount: null == amount
           ? _value.amount
@@ -106,8 +106,8 @@ abstract class _$$UserTransactionImplCopyWith<$Res>
   @useResult
   $Res call(
       {String transactionId,
-      String senderEmail,
-      String receiverEmail,
+      String senderUid,
+      String receiverUid,
       int amount,
       DateTime timestamp});
 }
@@ -126,8 +126,8 @@ class __$$UserTransactionImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? transactionId = null,
-    Object? senderEmail = null,
-    Object? receiverEmail = null,
+    Object? senderUid = null,
+    Object? receiverUid = null,
     Object? amount = null,
     Object? timestamp = null,
   }) {
@@ -136,13 +136,13 @@ class __$$UserTransactionImplCopyWithImpl<$Res>
           ? _value.transactionId
           : transactionId // ignore: cast_nullable_to_non_nullable
               as String,
-      senderEmail: null == senderEmail
-          ? _value.senderEmail
-          : senderEmail // ignore: cast_nullable_to_non_nullable
+      senderUid: null == senderUid
+          ? _value.senderUid
+          : senderUid // ignore: cast_nullable_to_non_nullable
               as String,
-      receiverEmail: null == receiverEmail
-          ? _value.receiverEmail
-          : receiverEmail // ignore: cast_nullable_to_non_nullable
+      receiverUid: null == receiverUid
+          ? _value.receiverUid
+          : receiverUid // ignore: cast_nullable_to_non_nullable
               as String,
       amount: null == amount
           ? _value.amount
@@ -161,8 +161,8 @@ class __$$UserTransactionImplCopyWithImpl<$Res>
 class _$UserTransactionImpl implements _UserTransaction {
   const _$UserTransactionImpl(
       {required this.transactionId,
-      required this.senderEmail,
-      required this.receiverEmail,
+      required this.senderUid,
+      required this.receiverUid,
       required this.amount,
       required this.timestamp});
 
@@ -173,10 +173,10 @@ class _$UserTransactionImpl implements _UserTransaction {
   final String transactionId;
 // 트랜잭션 고유 ID
   @override
-  final String senderEmail;
+  final String senderUid;
 // 보내는 사람 이메일
   @override
-  final String receiverEmail;
+  final String receiverUid;
 // 받는 사람 이메일
   @override
   final int amount;
@@ -186,7 +186,7 @@ class _$UserTransactionImpl implements _UserTransaction {
 
   @override
   String toString() {
-    return 'UserTransaction(transactionId: $transactionId, senderEmail: $senderEmail, receiverEmail: $receiverEmail, amount: $amount, timestamp: $timestamp)';
+    return 'UserTransaction(transactionId: $transactionId, senderUid: $senderUid, receiverUid: $receiverUid, amount: $amount, timestamp: $timestamp)';
   }
 
   @override
@@ -196,10 +196,10 @@ class _$UserTransactionImpl implements _UserTransaction {
             other is _$UserTransactionImpl &&
             (identical(other.transactionId, transactionId) ||
                 other.transactionId == transactionId) &&
-            (identical(other.senderEmail, senderEmail) ||
-                other.senderEmail == senderEmail) &&
-            (identical(other.receiverEmail, receiverEmail) ||
-                other.receiverEmail == receiverEmail) &&
+            (identical(other.senderUid, senderUid) ||
+                other.senderUid == senderUid) &&
+            (identical(other.receiverUid, receiverUid) ||
+                other.receiverUid == receiverUid) &&
             (identical(other.amount, amount) || other.amount == amount) &&
             (identical(other.timestamp, timestamp) ||
                 other.timestamp == timestamp));
@@ -207,8 +207,8 @@ class _$UserTransactionImpl implements _UserTransaction {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, transactionId, senderEmail,
-      receiverEmail, amount, timestamp);
+  int get hashCode => Object.hash(
+      runtimeType, transactionId, senderUid, receiverUid, amount, timestamp);
 
   /// Create a copy of UserTransaction
   /// with the given fields replaced by the non-null parameter values.
@@ -230,8 +230,8 @@ class _$UserTransactionImpl implements _UserTransaction {
 abstract class _UserTransaction implements UserTransaction {
   const factory _UserTransaction(
       {required final String transactionId,
-      required final String senderEmail,
-      required final String receiverEmail,
+      required final String senderUid,
+      required final String receiverUid,
       required final int amount,
       required final DateTime timestamp}) = _$UserTransactionImpl;
 
@@ -241,9 +241,9 @@ abstract class _UserTransaction implements UserTransaction {
   @override
   String get transactionId; // 트랜잭션 고유 ID
   @override
-  String get senderEmail; // 보내는 사람 이메일
+  String get senderUid; // 보내는 사람 이메일
   @override
-  String get receiverEmail; // 받는 사람 이메일
+  String get receiverUid; // 받는 사람 이메일
   @override
   int get amount; // 거래 금액
   @override

--- a/lib/model/user_transaction_model.g.dart
+++ b/lib/model/user_transaction_model.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_transaction_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$UserTransactionImpl _$$UserTransactionImplFromJson(
+        Map<String, dynamic> json) =>
+    _$UserTransactionImpl(
+      transactionId: json['transactionId'] as String,
+      senderEmail: json['senderEmail'] as String,
+      receiverEmail: json['receiverEmail'] as String,
+      amount: (json['amount'] as num).toInt(),
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+
+Map<String, dynamic> _$$UserTransactionImplToJson(
+        _$UserTransactionImpl instance) =>
+    <String, dynamic>{
+      'transactionId': instance.transactionId,
+      'senderEmail': instance.senderEmail,
+      'receiverEmail': instance.receiverEmail,
+      'amount': instance.amount,
+      'timestamp': instance.timestamp.toIso8601String(),
+    };

--- a/lib/model/user_transaction_model.g.dart
+++ b/lib/model/user_transaction_model.g.dart
@@ -10,8 +10,8 @@ _$UserTransactionImpl _$$UserTransactionImplFromJson(
         Map<String, dynamic> json) =>
     _$UserTransactionImpl(
       transactionId: json['transactionId'] as String,
-      senderEmail: json['senderEmail'] as String,
-      receiverEmail: json['receiverEmail'] as String,
+      senderUid: json['senderUid'] as String,
+      receiverUid: json['receiverUid'] as String,
       amount: (json['amount'] as num).toInt(),
       timestamp: DateTime.parse(json['timestamp'] as String),
     );
@@ -20,8 +20,8 @@ Map<String, dynamic> _$$UserTransactionImplToJson(
         _$UserTransactionImpl instance) =>
     <String, dynamic>{
       'transactionId': instance.transactionId,
-      'senderEmail': instance.senderEmail,
-      'receiverEmail': instance.receiverEmail,
+      'senderUid': instance.senderUid,
+      'receiverUid': instance.receiverUid,
       'amount': instance.amount,
       'timestamp': instance.timestamp.toIso8601String(),
     };

--- a/lib/view/tab/user/qr_tab.dart
+++ b/lib/view/tab/user/qr_tab.dart
@@ -195,7 +195,7 @@ class QrTab extends ConsumerWidget {
                     Spacer(), // 남은 공간을 채워 버튼이 하단에 위치하게 함
                     ElevatedButton(
                       onPressed: () {
-                        // 포인트를 보내는 기능
+                        Navigator.pushNamed(context, '/userSearch');// 포인트를 보내는 기능
                       },
                       child: Text('ポイントを送る'),
                       style: ElevatedButton.styleFrom(

--- a/lib/view/tab/user/user_home_screen.dart
+++ b/lib/view/tab/user/user_home_screen.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../viewModel/tab_view_model.dart';
 import 'user_settings_tab.dart';
 import 'qr_tab.dart';
-import 'user_transfer_screen.dart'; // 추가: 유저 포인트 거래 화면
+import 'user_search_screen.dart'; // 유저 검색 화면
+import 'user_transfer_screen.dart'; // 유저 포인트 거래 화면
+import 'user_transfer_confirm_screen.dart'; // 유저 포인트 거래 확인 화면
 
 // UserHomeScreen 클래스는 ConsumerWidget을 사용하여 상태 관리
 class UserHomeScreen extends ConsumerWidget {
@@ -70,9 +72,17 @@ class QrTabNavigator extends StatelessWidget {
     return Navigator(
       onGenerateRoute: (settings) {
         switch (settings.name) {
+          case '/userSearch': // 새 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => UserSearchScreen(), // user_transfer_screen.dart에 있는 화면으로 연결
+            );
           case '/userTransfer': // 새 경로 추가
             return MaterialPageRoute(
               builder: (context) => UserTransferScreen(), // user_transfer_screen.dart에 있는 화면으로 연결
+            );
+          case '/userTransferConfirm': // 새 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => UserTransferConfirmScreen(), // user_transfer_screen.dart에 있는 화면으로 연결
             );
           default:
             return MaterialPageRoute(

--- a/lib/view/tab/user/user_search_screen.dart
+++ b/lib/view/tab/user/user_search_screen.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../viewModel/user_point_uid_view_model.dart';
+
+class UserSearchScreen extends ConsumerWidget {
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userState = ref.watch(userPointsUidProvider).userState;
+
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: EdgeInsets.only(left: screenWidth * 0.05, top: screenHeight * 0.03),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(height: screenHeight * 0.05),
+                Text(
+                  'クーポンを送る',
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontSize: screenWidth * 0.06,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(height: screenHeight * 0.02),
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.04),
+            child: Column(
+              children: [
+                TextField(
+                  controller: _searchController,
+                  onChanged: (value) {
+                    ref.read(userPointsUidProvider.notifier).searchUserByNameOrUid(value);
+                  },
+                  decoration: InputDecoration(
+                    filled: true,
+                    fillColor: Colors.grey[200],
+                    contentPadding: EdgeInsets.symmetric(vertical: screenHeight * 0.02),
+                    prefixIcon: Icon(Icons.person_outline, color: Colors.grey, size: screenWidth * 0.06),
+                    suffixIcon: IconButton(
+                      icon: Icon(Icons.highlight_off, color: Colors.grey, size: screenWidth * 0.05),
+                      onPressed: () {
+                        _searchController.clear();
+                        ref.read(userPointsUidProvider.notifier).searchUserByNameOrUid('');
+                      },
+                    ),
+                    hintText: 'AceClub IDまたは会員番号',
+                    hintStyle: TextStyle(color: Colors.grey[600], fontSize: screenWidth * 0.04),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(screenWidth * 0.08),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+                SizedBox(height: screenHeight * 0.02),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.04),
+              child: userState.when(
+                data: (users) {
+                  if (users.isEmpty) {
+                    return Center(child: Text('사용자를 검색해 주세요'));
+                  }
+                  return ListView.builder(
+                    itemCount: users.length,
+                    itemBuilder: (context, index) {
+                      final user = users[index];
+                      return Column(
+                        children: [
+                          InkWell(
+                            onTap: () {
+                              ref.read(userPointsUidProvider.notifier).updateUserByUid(user.uid);
+                              Navigator.pushNamed(
+                                context,
+                                '/userTransfer',
+                                arguments: user,
+                              );
+                            },
+                            child: Padding(
+                              padding: EdgeInsets.only(
+                                  top: screenHeight * 0.015,
+                                  bottom: screenHeight * 0.007),
+                              child: Row(
+                                children: [
+                                  CircleAvatar(
+                                    radius: screenWidth * 0.07,
+                                    backgroundColor: Colors.grey,
+                                    foregroundImage: user.profilePicUrl != null
+                                        ? NetworkImage(user.profilePicUrl!)
+                                        : null,
+                                    child: user.profilePicUrl == null
+                                        ? Icon(Icons.person,
+                                            size: screenWidth * 0.06, color: Colors.white)
+                                        : null,
+                                  ),
+                                  SizedBox(width: screenWidth * 0.04),
+                                  Expanded(
+                                    child: Stack(
+                                      children: [
+                                        Align(
+                                          alignment: Alignment.centerLeft,
+                                          child: Text(
+                                            user.name,
+                                            style: TextStyle(
+                                              fontSize: screenWidth * 0.05,
+                                              fontWeight: FontWeight.bold,
+                                              color: Colors.black,
+                                            ),
+                                          ),
+                                        ),
+                                        Align(
+                                          alignment: Alignment.bottomRight,
+                                          child: Padding(
+                                            padding: EdgeInsets.only(top: screenHeight * 0.01),
+                                            child: Text(
+                                              user.uid,
+                                              style: TextStyle(
+                                                fontSize: screenWidth * 0.04,
+                                                color: Colors.grey,
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          Divider(
+                            color: Colors.grey[300],
+                            thickness: 1,
+                            height: screenHeight * 0.002,
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+                loading: () => Center(child: CircularProgressIndicator()),
+                error: (error, stackTrace) => Center(child: Text('오류 발생: $error')),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/tab/user/user_search_screen.dart
+++ b/lib/view/tab/user/user_search_screen.dart
@@ -2,11 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../viewModel/user_point_uid_view_model.dart';
 
-class UserSearchScreen extends ConsumerWidget {
+class UserSearchScreen extends ConsumerStatefulWidget {
+  @override
+  _UserSearchScreenState createState() => _UserSearchScreenState();
+}
+
+class _UserSearchScreenState extends ConsumerState<UserSearchScreen> {
   final TextEditingController _searchController = TextEditingController();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  void dispose() {
+    _searchController.dispose(); // 메모리 누수 방지
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final userState = ref.watch(userPointsUidProvider).userState;
 
     final screenSize = MediaQuery.of(context).size;

--- a/lib/view/tab/user/user_transfer_confirm_screen.dart
+++ b/lib/view/tab/user/user_transfer_confirm_screen.dart
@@ -2,20 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../../viewModel/user_point_uid_view_model.dart';
+import '../../../model/user_model.dart';
+import '../../../model/user_transaction_model.dart';
 
-class UserTransferConfirmScreen extends ConsumerWidget {
+class UserTransferConfirmScreen extends ConsumerStatefulWidget {
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // 화면 크기와 포맷터 정의
+  _UserTransferConfirmScreenState createState() => _UserTransferConfirmScreenState();
+}
+
+class _UserTransferConfirmScreenState extends ConsumerState<UserTransferConfirmScreen> {
+  final numberFormat = NumberFormat("#,###");
+  AsyncValue<UserTransaction>? transaction;
+  AsyncValue<List<User>>? userState;
+
+  @override
+  void initState() {
+    super.initState();
+    // transaction과 userState를 한 번만 가져오도록 초기화
+    transaction = ref.read(userPointsUidProvider).transactionState;
+    userState = ref.read(userPointsUidProvider).userState;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
     final screenWidth = screenSize.width;
     final screenHeight = screenSize.height;
-    final numberFormat = NumberFormat("#,###");
 
-    // transactionProvider 상태 구독
-    final transaction = ref.watch(userPointsUidProvider).transactionState.value;
-    final userState = ref.watch(userPointsUidProvider).userState;
-    final user = userState.when(
+    final user = userState?.when(
       data: (users) => users.isNotEmpty ? users.first : null,
       loading: () => null,
       error: (error, _) => null,
@@ -103,7 +117,7 @@ class UserTransferConfirmScreen extends ConsumerWidget {
                 textBaseline: TextBaseline.alphabetic,
                 children: [
                   Text(
-                    '${numberFormat.format(transaction?.amount ?? 0)}',
+                    '${numberFormat.format(transaction?.value?.amount ?? 0)}',
                     style: TextStyle(
                       fontSize: screenWidth * 0.12,
                       fontWeight: FontWeight.bold,

--- a/lib/view/tab/user/user_transfer_confirm_screen.dart
+++ b/lib/view/tab/user/user_transfer_confirm_screen.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../viewModel/user_point_uid_view_model.dart';
+
+class UserTransferConfirmScreen extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 화면 크기와 포맷터 정의
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+    final numberFormat = NumberFormat("#,###");
+
+    // transactionProvider 상태 구독
+    final transaction = ref.watch(userPointsUidProvider).transactionState.value;
+    final userState = ref.watch(userPointsUidProvider).userState;
+    final user = userState.when(
+      data: (users) => users.isNotEmpty ? users.first : null,
+      loading: () => null,
+      error: (error, _) => null,
+    );
+
+    // 사용자 프로필 URL 가져오기
+    final profilePicUrl = user?.profilePicUrl;
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: Padding(
+        padding: EdgeInsets.all(screenWidth * 0.06),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 상단 타이틀
+            Padding(
+              padding: EdgeInsets.only(top: screenHeight * 0.05),
+              child: Text(
+                '完了',
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: screenWidth * 0.07,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            SizedBox(height: screenHeight * 0.04),
+
+            // 사용자 정보 영역
+            Container(
+              padding: EdgeInsets.symmetric(
+                horizontal: screenWidth * 0.04,
+                vertical: screenHeight * 0.02,
+              ),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(screenWidth * 0.03),
+                border: Border.all(color: Colors.grey.shade300),
+              ),
+              child: Row(
+                children: [
+                  CircleAvatar(
+                    radius: screenWidth * 0.07,
+                    backgroundColor: Colors.grey,
+                    backgroundImage: (profilePicUrl != null && profilePicUrl.isNotEmpty)
+                        ? NetworkImage(profilePicUrl)
+                        : null,
+                    child: (profilePicUrl == null || profilePicUrl.isEmpty)
+                        ? Icon(Icons.person, size: screenWidth * 0.07, color: Colors.white)
+                        : null,
+                  ),
+                  SizedBox(width: screenWidth * 0.04),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        user?.name ?? 'ユーザー名',
+                        style: TextStyle(
+                          fontSize: screenWidth * 0.045,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        user?.uid ?? '0000-0000-0000',
+                        style: TextStyle(
+                          fontSize: screenWidth * 0.035,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(height: screenHeight * 0.03),
+            Divider(thickness: 1, color: Colors.grey.shade300),
+            SizedBox(height: screenHeight * 0.03),
+
+            // 포인트 표시 영역
+            Align(
+              alignment: Alignment.center,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    '${numberFormat.format(transaction?.amount ?? 0)}',
+                    style: TextStyle(
+                      fontSize: screenWidth * 0.12,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.black,
+                    ),
+                  ),
+                  SizedBox(width: screenWidth * 0.01),
+                  Text(
+                    'pt',
+                    style: TextStyle(
+                      fontSize: screenWidth * 0.045,
+                      color: Colors.grey,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(height: screenHeight * 0.04),
+
+            // "受け取り完了" 버튼
+            Center(
+              child: Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: screenWidth * 0.12,
+                  vertical: screenHeight * 0.012,
+                ),
+                decoration: BoxDecoration(
+                  color: Colors.green,
+                  borderRadius: BorderRadius.circular(screenWidth * 0.07),
+                ),
+                child: Text(
+                  '受け取り完了',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: screenWidth * 0.045,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            Spacer(),
+
+            // "ホームへ" 버튼
+            Center(
+              child: GestureDetector(
+                onTap: () {
+                  ref.read(userPointsUidProvider.notifier).clearUserAndTransactionState();
+                  Navigator.popUntil(context, (route) => route.isFirst);
+                },
+                child: Container(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: screenWidth * 0.3,
+                    vertical: screenHeight * 0.015,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Color(0xFF1D2538),
+                    borderRadius: BorderRadius.circular(screenWidth * 0.1),
+                  ),
+                  child: Center(
+                    child: Text(
+                      'ホームへ',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: screenWidth * 0.045,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(height: screenHeight * 0.05),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/tab/user/user_transfer_screen.dart
+++ b/lib/view/tab/user/user_transfer_screen.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../viewModel/user_point_uid_view_model.dart';
+import '../../../model/user_model.dart';
+
+class UserTransferScreen extends ConsumerStatefulWidget {
+  @override
+  _UserTransferScreenState createState() => _UserTransferScreenState();
+}
+
+class _UserTransferScreenState extends ConsumerState<UserTransferScreen> {
+  final numberFormat = NumberFormat("#,###");
+
+  AsyncValue<List<User>>? userState;
+
+  @override
+  void initState() {
+    super.initState();
+    userState = ref.read(userPointsUidProvider).userState;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final transactionAmount = ref.watch(userPointsUidProvider).transactionState.whenData((transaction) => transaction.amount).value ?? 0;
+
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: userState!.when(
+          data: (users) {
+            if (users.isEmpty) {
+              return Center(child: Text('사용자를 찾을 수 없습니다.'));
+            }
+            final user = users.first;
+
+            return Padding(
+              padding: EdgeInsets.all(screenWidth * 0.05),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(height: screenHeight * 0.05),
+                  Text(
+                    'ポイント入力',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: screenWidth * 0.07,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  SizedBox(height: screenHeight * 0.03),
+                  Center(
+                    child: Column(
+                      children: [
+                        CircleAvatar(
+                          radius: screenWidth * 0.15,
+                          backgroundColor: Colors.grey,
+                          foregroundImage: user.profilePicUrl != null
+                              ? NetworkImage(user.profilePicUrl!)
+                              : null,
+                          child: user.profilePicUrl == null
+                              ? Icon(Icons.person, size: screenWidth * 0.15, color: Colors.white)
+                              : null,
+                        ),
+                        SizedBox(height: screenHeight * 0.01),
+                        Text(
+                          user.name,
+                          style: TextStyle(
+                            fontSize: screenWidth * 0.08,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.black,
+                          ),
+                        ),
+                        Text(
+                          user.uid,
+                          style: TextStyle(
+                            fontSize: screenWidth * 0.04,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  SizedBox(height: screenHeight * 0.015),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.baseline,
+                      textBaseline: TextBaseline.alphabetic,
+                      children: [
+                        Text(
+                          '${numberFormat.format(transactionAmount)}',
+                          style: TextStyle(
+                            fontSize: screenWidth * 0.08,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.black,
+                          ),
+                        ),
+                        SizedBox(width: screenWidth * 0.01),
+                        Text(
+                          'pt',
+                          style: TextStyle(
+                            fontSize: screenWidth * 0.04,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    height: screenHeight * 0.35,
+                    child: GridView.count(
+                      crossAxisCount: 3,
+                      childAspectRatio: 2,
+                      mainAxisSpacing: screenHeight * 0.005,
+                      crossAxisSpacing: screenWidth * 0.01,
+                      physics: NeverScrollableScrollPhysics(),
+                      children: List.generate(12, (index) {
+                        String displayText;
+                        if (index == 9) {
+                          displayText = 'C';
+                        } else if (index == 11) {
+                          return IconButton(
+                            icon: Icon(Icons.backspace, size: screenWidth * 0.07),
+                            onPressed: () {
+                              final currentAmount = transactionAmount.toString();
+                              if (currentAmount.isNotEmpty && currentAmount != '0') {
+                                final newAmount = currentAmount.substring(0, currentAmount.length - 1);
+                                ref.read(userPointsUidProvider.notifier).updateAmount(int.parse(newAmount.isEmpty ? '0' : newAmount));
+                              }
+                            },
+                          );
+                        } else {
+                          displayText = index == 10 ? '0' : '${index + 1}';
+                        }
+
+                        return GestureDetector(
+                          onTap: () {
+                            if (displayText == 'C') {
+                              ref.read(userPointsUidProvider.notifier).updateAmount(0);
+                            } else {
+                              final currentAmount = transactionAmount.toString();
+                              if (currentAmount == '0') {
+                                final newAmountStr = displayText;
+                                ref.read(userPointsUidProvider.notifier).updateAmount(int.parse(newAmountStr));
+                              } else if (currentAmount.length < 9) {
+                                final newAmountStr = currentAmount + displayText;
+                                ref.read(userPointsUidProvider.notifier).updateAmount(int.parse(newAmountStr));
+                              }
+                            }
+                          },
+                          child: Container(
+                            margin: EdgeInsets.all(screenWidth * 0.01),
+                            decoration: BoxDecoration(
+                              color: Colors.grey.shade200,
+                              borderRadius: BorderRadius.circular(screenWidth * 0.02),
+                            ),
+                            child: Center(
+                              child: Text(
+                                displayText,
+                                style: TextStyle(fontSize: screenWidth * 0.05, color: Colors.black),
+                              ),
+                            ),
+                          ),
+                        );
+                      }),
+                    ),
+                  ),
+                  SizedBox(height: screenHeight * 0.02),
+                  Center(
+                    child: ElevatedButton(
+                      onPressed: transactionAmount > 0
+                          ? () async {
+                              final success = await ref.read(userPointsUidProvider.notifier).performTransaction(user);
+
+                              if (success) {
+                                Navigator.pushNamed(context, '/userTransferConfirm');
+                              } else {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text('포인트가 부족합니다.')),
+                                );
+                              }
+                            }
+                          : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: transactionAmount > 0 ? Color(0xFF1D2538) : Colors.grey,
+                        padding: EdgeInsets.symmetric(
+                          horizontal: screenWidth * 0.35,
+                          vertical: screenHeight * 0.015,
+                        ),
+                      ),
+                      child: Text(
+                        '確認',
+                        style: TextStyle(
+                          fontSize: screenWidth * 0.045,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+          loading: () => Center(child: CircularProgressIndicator()),
+          error: (error, stackTrace) => Center(child: Text('오류 발생: $error')),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/viewModel/user_point_uid_view_model.dart
+++ b/lib/viewModel/user_point_uid_view_model.dart
@@ -134,8 +134,8 @@ class UserPointsUidViewModel extends StateNotifier<UserPointsUidState> {
 
       // Transactions 컬렉션에 거래 정보 추가
       final transactionRef = await FirebaseFirestore.instance.collection('Transactions').add({
-        'userId': senderUid,                 // senderUid를 저장
-        'receiverUid': receiverUser.uid,        // receiverUid를 저장
+        'relatedUserId': senderUid,                 // senderUid를 저장
+        'userId': receiverUser.uid,        // receiverUid를 저장
         'amount': transactionAmount,
         'timestamp': DateTime.now(),
       });

--- a/lib/viewModel/user_point_uid_view_model.dart
+++ b/lib/viewModel/user_point_uid_view_model.dart
@@ -1,0 +1,198 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../model/user_model.dart';
+import '../model/user_transaction_model.dart';
+import '../services/preferences_manager.dart';
+
+class UserPointsUidViewModel extends StateNotifier<UserPointsUidState> {
+  UserPointsUidViewModel() : super(UserPointsUidState());
+
+  // Firestore에서 name 또는 uid로 사용자 검색
+  Future<void> searchUserByNameOrUid(String query) async {
+    if (query.isEmpty) {
+      state = state.copyWith(userState: const AsyncValue.data([])); // 검색어가 비어있으면 빈 리스트로 초기화
+      return;
+    }
+
+    try {
+      final users = <User>[];
+
+      // 현재 사용자의 이메일 가져오기
+      final currentUserEmail = await PreferencesManager.instance.getEmail();
+
+      // 이름으로 검색
+      final nameSnapshot = await FirebaseFirestore.instance
+          .collection('users')
+          .where('name', isGreaterThanOrEqualTo: query)
+          .where('name', isLessThan: query + 'z')
+          .get();
+
+      if (nameSnapshot.docs.isNotEmpty) {
+        users.addAll(nameSnapshot.docs.map((doc) {
+          return User.fromJson(doc.data()..['uid'] = doc.id);
+        }));
+      }
+
+      // UID로 검색
+      final uidSnapshot = await FirebaseFirestore.instance
+          .collection('users')
+          .where('uid', isEqualTo: query)
+          .get();
+
+      if (uidSnapshot.docs.isNotEmpty) {
+        users.addAll(uidSnapshot.docs.map((doc) {
+          return User.fromJson(doc.data()..['uid'] = doc.id);
+        }));
+      }
+
+      // 중복 사용자 제거 및 자신을 제외한 유저 리스트 생성
+      final uniqueUsers = {
+        for (var user in users)
+          if (user.email != currentUserEmail) user.uid: user
+      }.values.toList();
+
+      // 사용자 상태 업데이트
+      state = state.copyWith(userState: AsyncValue.data(uniqueUsers));
+    } catch (e) {
+      print('Error searching user by name or UID: $e');
+      state = state.copyWith(userState: AsyncValue.error('사용자 검색 중 오류가 발생했습니다.', StackTrace.current));
+    }
+  }
+
+  // Firestore에서 특정 UID로 사용자 정보를 가져와 업데이트하는 함수
+  Future<void> updateUserByUid(String uid) async {
+    try {
+      final userDoc = await FirebaseFirestore.instance.collection('users').doc(uid).get();
+
+      if (userDoc.exists) {
+        final userData = userDoc.data();
+        if (userData != null) {
+          final updatedUser = User(
+            uid: uid,
+            name: userData['name'] ?? '',
+            email: userData['email'] ?? '',
+            points: userData['points'] ?? 0,
+            authType: userData['authType'] ?? '',
+            profilePicUrl: userData['profilePicUrl'],
+            pubId: userData['pubId'],
+          );
+
+          state = state.copyWith(userState: AsyncValue.data([updatedUser]));
+        }
+      } else {
+        print("User not found in Firestore.");
+        state = state.copyWith(userState: const AsyncValue.data([]));
+      }
+    } catch (e) {
+      print('Error updating user data by UID: $e');
+      state = state.copyWith(userState: AsyncValue.error('사용자 정보 업데이트 중 오류가 발생했습니다.', StackTrace.current));
+    }
+  }
+
+  // UserTransaction의 amount를 업데이트하는 함수
+  void updateAmount(int newAmount) {
+    state = state.copyWith(transactionState: state.transactionState.whenData((transaction) {
+      return transaction.copyWith(amount: newAmount);
+    }));
+  }
+
+  // 거래를 수행하고 Firestore에 저장하는 함수
+  Future<bool> performTransaction(User receiverUser) async {
+    final senderEmail = await PreferencesManager.instance.getEmail();
+    final transactionAmount = state.transactionState.value?.amount ?? 0;
+
+    if (senderEmail == null) {
+      print("Sender email not found.");
+      return false; // 실패 시 false 반환
+    }
+
+    try {
+      // Firestore에서 sender의 points를 가져와 검증
+      final senderDoc = await FirebaseFirestore.instance.collection('users').where('email', isEqualTo: senderEmail).get();
+      if (senderDoc.docs.isEmpty) {
+        print("Sender not found.");
+        return false; // 실패 시 false 반환
+      }
+
+      final senderData = senderDoc.docs.first.data();
+      final senderPoints = senderData['points'] ?? 0;
+
+      if (transactionAmount > senderPoints) {
+        print("포인트가 부족합니다.");
+        return false; // 실패 시 false 반환
+      }
+
+      // sender와 receiver의 포인트 업데이트
+      final senderDocRef = FirebaseFirestore.instance.collection('users').doc(senderDoc.docs.first.id);
+      final receiverDocRef = FirebaseFirestore.instance.collection('users').doc(receiverUser.uid);
+
+      await FirebaseFirestore.instance.runTransaction((transaction) async {
+        transaction.update(senderDocRef, {'points': senderPoints - transactionAmount});
+        transaction.update(receiverDocRef, {'points': receiverUser.points + transactionAmount});
+      });
+
+      // Transactions 컬렉션에 거래 정보 추가
+      final transactionRef = await FirebaseFirestore.instance.collection('Transactions').add({
+        'senderEmail': senderEmail,
+        'receiverEmail': receiverUser.email,
+        'amount': transactionAmount,
+        'timestamp': DateTime.now(),
+      });
+
+      // 트랜잭션 문서 ID를 transactionId 필드에 업데이트
+      await transactionRef.update({'transactionId': transactionRef.id});
+
+      print("거래가 성공적으로 완료되었습니다.");
+      return true; // 성공 시 true 반환
+    } catch (e) {
+      print("거래 중 오류 발생: $e");
+      return false; // 오류 발생 시 false 반환
+    }
+  }
+
+  // userState와 transactionState를 초기화하는 함수
+  void clearUserAndTransactionState() {
+    state = UserPointsUidState(
+      userState: const AsyncValue.data([]),
+      transactionState: AsyncValue.data(UserTransaction(
+        transactionId: '',
+        senderEmail: '',
+        receiverEmail: '',
+        amount: 0,
+        timestamp: DateTime.now(),
+      )),
+    );
+  }
+}
+
+// 상태를 분리하여 관리하기 위한 State 클래스 정의
+class UserPointsUidState {
+  final AsyncValue<List<User>> userState;
+  final AsyncValue<UserTransaction> transactionState;
+
+  UserPointsUidState({
+    this.userState = const AsyncValue.data([]),
+    AsyncValue<UserTransaction>? transactionState,
+  }) : transactionState = transactionState ?? AsyncValue.data(UserTransaction(
+          transactionId: '',
+          senderEmail: '',
+          receiverEmail: '',
+          amount: 0,
+          timestamp: DateTime.now(),
+        ));
+
+  UserPointsUidState copyWith({
+    AsyncValue<List<User>>? userState,
+    AsyncValue<UserTransaction>? transactionState,
+  }) {
+    return UserPointsUidState(
+      userState: userState ?? this.userState,
+      transactionState: transactionState ?? this.transactionState,
+    );
+  }
+}
+
+// ViewModel Provider
+final userPointsUidProvider = StateNotifierProvider<UserPointsUidViewModel, UserPointsUidState>((ref) {
+  return UserPointsUidViewModel();
+});

--- a/lib/viewModel/user_point_uid_view_model.dart
+++ b/lib/viewModel/user_point_uid_view_model.dart
@@ -107,7 +107,7 @@ class UserPointsUidViewModel extends StateNotifier<UserPointsUidState> {
     }
 
     try {
-      // Firestore에서 sender의 points를 가져와 검증
+      // Firestore에서 sender의 uid를 가져와 검증
       final senderDoc = await FirebaseFirestore.instance.collection('users').where('email', isEqualTo: senderEmail).get();
       if (senderDoc.docs.isEmpty) {
         print("Sender not found.");
@@ -115,6 +115,7 @@ class UserPointsUidViewModel extends StateNotifier<UserPointsUidState> {
       }
 
       final senderData = senderDoc.docs.first.data();
+      final senderUid = senderDoc.docs.first.id; // sender의 uid
       final senderPoints = senderData['points'] ?? 0;
 
       if (transactionAmount > senderPoints) {
@@ -123,7 +124,7 @@ class UserPointsUidViewModel extends StateNotifier<UserPointsUidState> {
       }
 
       // sender와 receiver의 포인트 업데이트
-      final senderDocRef = FirebaseFirestore.instance.collection('users').doc(senderDoc.docs.first.id);
+      final senderDocRef = FirebaseFirestore.instance.collection('users').doc(senderUid);
       final receiverDocRef = FirebaseFirestore.instance.collection('users').doc(receiverUser.uid);
 
       await FirebaseFirestore.instance.runTransaction((transaction) async {
@@ -133,8 +134,8 @@ class UserPointsUidViewModel extends StateNotifier<UserPointsUidState> {
 
       // Transactions 컬렉션에 거래 정보 추가
       final transactionRef = await FirebaseFirestore.instance.collection('Transactions').add({
-        'senderEmail': senderEmail,
-        'receiverEmail': receiverUser.email,
+        'uid': senderUid,                 // senderUid를 저장
+        'receiverUid': receiverUser.uid,        // receiverUid를 저장
         'amount': transactionAmount,
         'timestamp': DateTime.now(),
       });
@@ -156,8 +157,8 @@ class UserPointsUidViewModel extends StateNotifier<UserPointsUidState> {
       userState: const AsyncValue.data([]),
       transactionState: AsyncValue.data(UserTransaction(
         transactionId: '',
-        senderEmail: '',
-        receiverEmail: '',
+        senderUid: '',
+        receiverUid: '',
         amount: 0,
         timestamp: DateTime.now(),
       )),
@@ -175,8 +176,8 @@ class UserPointsUidState {
     AsyncValue<UserTransaction>? transactionState,
   }) : transactionState = transactionState ?? AsyncValue.data(UserTransaction(
           transactionId: '',
-          senderEmail: '',
-          receiverEmail: '',
+          senderUid: '',
+          receiverUid: '',
           amount: 0,
           timestamp: DateTime.now(),
         ));

--- a/lib/viewModel/user_point_uid_view_model.dart
+++ b/lib/viewModel/user_point_uid_view_model.dart
@@ -134,7 +134,7 @@ class UserPointsUidViewModel extends StateNotifier<UserPointsUidState> {
 
       // Transactions 컬렉션에 거래 정보 추가
       final transactionRef = await FirebaseFirestore.instance.collection('Transactions').add({
-        'uid': senderUid,                 // senderUid를 저장
+        'userId': senderUid,                 // senderUid를 저장
         'receiverUid': receiverUser.uid,        // receiverUid를 저장
         'amount': transactionAmount,
         'timestamp': DateTime.now(),


### PR DESCRIPTION
lib/model/user_model.dart: profilePic 프로필 사진을 추가하였습니다.

lib/model/user_transaction_model.dart: 유저 거래 모델을 새롭게 추가하였습니다.

lib/view/tab/user/qr_tab.dart: QR Code 탭에서 ポイントを送る버튼을 누르면  /userSearch 유저를 검색하는 화면으로 넘어가도록 하였습니다.

lib/view/tab/user/user_home_screen.dart: qr_tab과 이어지는 경로 들을 추가 하였습니다.
user_search_screen 유저 검색 화면
user_transfer_screen 유저 포인트 거래 화면
user_transfer_confirm_screen 유저 포인트 거래 확인 화면

lib/view/tab/user/user_search_screen.dart: 사용자를  users 컬렉션의 name과 uid로 검색 할 수 있는 화면입니다.

lib/view/tab/user/user_transfer_screen.dart: 선택한 유저에게 보낼 포인트를 입력하는 화면입니다.

lib/view/tab/user/user_transfer_confirm_screen.dart:  포인트 거래 확인 화면입니다.

lib/viewModel/user_point_uid_view_model.dart: 앞의 세 화면의 viewmodel입니다.
유저 거래내역 화면에서 거래내역 검색을 편하게 하기위해 firestore에는 senderUid를  relatedUserId, receiverUser를 userId로 저장하였습니다.

