### PR TITLE
user account 탭구현

### DIFF
--- a/lib/model/store_model.dart
+++ b/lib/model/store_model.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'store_model.freezed.dart';
+part 'store_model.g.dart';
+
+@freezed
+class Store with _$Store {
+  const factory Store({
+    required String storeName,
+  }) = _Store;
+
+  factory Store.fromJson(Map<String, dynamic> json) => _$StoreFromJson(json);
+}

--- a/lib/model/store_model.freezed.dart
+++ b/lib/model/store_model.freezed.dart
@@ -1,0 +1,161 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'store_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Store _$StoreFromJson(Map<String, dynamic> json) {
+  return _Store.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Store {
+  String get storeName => throw _privateConstructorUsedError;
+
+  /// Serializes this Store to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Store
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $StoreCopyWith<Store> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StoreCopyWith<$Res> {
+  factory $StoreCopyWith(Store value, $Res Function(Store) then) =
+      _$StoreCopyWithImpl<$Res, Store>;
+  @useResult
+  $Res call({String storeName});
+}
+
+/// @nodoc
+class _$StoreCopyWithImpl<$Res, $Val extends Store>
+    implements $StoreCopyWith<$Res> {
+  _$StoreCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Store
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeName = null,
+  }) {
+    return _then(_value.copyWith(
+      storeName: null == storeName
+          ? _value.storeName
+          : storeName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$StoreImplCopyWith<$Res> implements $StoreCopyWith<$Res> {
+  factory _$$StoreImplCopyWith(
+          _$StoreImpl value, $Res Function(_$StoreImpl) then) =
+      __$$StoreImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String storeName});
+}
+
+/// @nodoc
+class __$$StoreImplCopyWithImpl<$Res>
+    extends _$StoreCopyWithImpl<$Res, _$StoreImpl>
+    implements _$$StoreImplCopyWith<$Res> {
+  __$$StoreImplCopyWithImpl(
+      _$StoreImpl _value, $Res Function(_$StoreImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Store
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeName = null,
+  }) {
+    return _then(_$StoreImpl(
+      storeName: null == storeName
+          ? _value.storeName
+          : storeName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$StoreImpl implements _Store {
+  const _$StoreImpl({required this.storeName});
+
+  factory _$StoreImpl.fromJson(Map<String, dynamic> json) =>
+      _$$StoreImplFromJson(json);
+
+  @override
+  final String storeName;
+
+  @override
+  String toString() {
+    return 'Store(storeName: $storeName)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StoreImpl &&
+            (identical(other.storeName, storeName) ||
+                other.storeName == storeName));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, storeName);
+
+  /// Create a copy of Store
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StoreImplCopyWith<_$StoreImpl> get copyWith =>
+      __$$StoreImplCopyWithImpl<_$StoreImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$StoreImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Store implements Store {
+  const factory _Store({required final String storeName}) = _$StoreImpl;
+
+  factory _Store.fromJson(Map<String, dynamic> json) = _$StoreImpl.fromJson;
+
+  @override
+  String get storeName;
+
+  /// Create a copy of Store
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$StoreImplCopyWith<_$StoreImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/store_model.g.dart
+++ b/lib/model/store_model.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'store_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$StoreImpl _$$StoreImplFromJson(Map<String, dynamic> json) => _$StoreImpl(
+      storeName: json['storeName'] as String,
+    );
+
+Map<String, dynamic> _$$StoreImplToJson(_$StoreImpl instance) =>
+    <String, dynamic>{
+      'storeName': instance.storeName,
+    };

--- a/lib/view/tab/user/update_pubid_screen.dart
+++ b/lib/view/tab/user/update_pubid_screen.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../viewModel/user_update_pubid_view_model.dart';
+import '../../../viewModel/user_account_view_model.dart';
+
+class UpdatePubIdScreen extends ConsumerStatefulWidget {
+  @override
+  _UpdatePubIdScreenState createState() => _UpdatePubIdScreenState();
+}
+
+class _UpdatePubIdScreenState extends ConsumerState<UpdatePubIdScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Firestore에서 데이터를 가져옵니다.
+    ref.read(updatePubIdViewModelProvider.notifier).fetchStoresFromFirestore();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = ref.read(updatePubIdViewModelProvider.notifier);
+    final filteredStoreNames = ref.watch(updatePubIdViewModelProvider.select((state) => state.filteredStores));
+    final selectedStoreName = ref.watch(updatePubIdViewModelProvider.select((state) => state.selectedStore));
+
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'ご利用店舗選択',
+          style: TextStyle(fontSize: screenWidth * 0.045), // 상대 크기 설정
+        ),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.05),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(height: screenHeight * 0.02), // 상대 크기 설정
+            // 검색 필드
+            TextField(
+              onChanged: (query) {
+                final trimmedQuery = query.trim();
+                print('입력된 검색어: $trimmedQuery');
+                viewModel.filterStores(trimmedQuery);
+              },
+              decoration: InputDecoration(
+                contentPadding: EdgeInsets.symmetric(vertical: screenHeight * 0.015),
+                hintText: '検索',
+                hintStyle: TextStyle(fontSize: screenWidth * 0.04), // 상대 크기 설정
+                prefixIcon: Icon(Icons.search, size: screenWidth * 0.05, color: Colors.grey),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(screenWidth * 0.05),
+                  borderSide: BorderSide(color: Colors.grey[300]!, width: screenWidth * 0.002),
+                ),
+              ),
+            ),
+            SizedBox(height: screenHeight * 0.02),
+            // 필터링된 매장 리스트
+            Expanded(
+              child: filteredStoreNames.isEmpty
+                  ? Center(
+                      child: Text(
+                        '検索結果がありません。',
+                        style: TextStyle(fontSize: screenWidth * 0.045, color: Colors.grey),
+                      ),
+                    )
+                  : ListView.separated(
+                      itemCount: filteredStoreNames.length,
+                      separatorBuilder: (context, index) => Divider(
+                        color: Colors.grey[300],
+                        thickness: screenHeight * 0.001, // 상대 크기 설정
+                        height: screenHeight * 0.01, // 상대 크기 설정
+                      ),
+                      itemBuilder: (context, index) {
+                        final storeName = filteredStoreNames[index];
+                        return _buildStoreTile(
+                          context,
+                          viewModel,
+                          storeName,
+                          screenWidth,
+                          screenHeight,
+                          selectedStoreName,
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // 매장 타일 위젯
+  Widget _buildStoreTile(
+    BuildContext context,
+    UpdatePubIdViewModel viewModel,
+    String storeName,
+    double screenWidth,
+    double screenHeight,
+    String? selectedStoreName,
+  ) {
+    return Column(
+      children: [
+        ListTile(
+          contentPadding: EdgeInsets.symmetric(vertical: screenHeight * 0.015),
+          title: Text(
+            storeName,
+            style: TextStyle(
+              fontSize: screenWidth * 0.045,
+              color: storeName == selectedStoreName ? Colors.blue : Colors.black,
+              fontWeight: storeName == selectedStoreName ? FontWeight.bold : FontWeight.normal,
+            ),
+          ),
+          onTap: () async {
+            final isSuccess = await viewModel.updateSelectedStoreAndPubId(storeName);
+            if (isSuccess) {
+              ref.read(userAccountProvider.notifier).updatePubId(storeName);
+              Navigator.pop(context); // 성공 시 이전 화면으로 이동
+            } else {
+              _showSnackBar(context, '更新に失敗しました。'); // 실패 시 에러 메시지 표시
+            }
+          },
+        ),
+        Divider(
+          color: Colors.grey[300],
+          thickness: screenHeight * 0.001, // 상대 크기 설정
+          height: screenHeight * 0.01, // 상대 크기 설정
+        ),
+      ],
+    );
+  }
+
+  // 스낵바 표시
+  void _showSnackBar(BuildContext context, String message) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: TextStyle(fontSize: screenWidth * 0.04), // 상대 크기 설정
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/tab/user/user_account_screen.dart
+++ b/lib/view/tab/user/user_account_screen.dart
@@ -1,0 +1,262 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../viewModel/user_account_view_model.dart';
+import '../../../services/auth_service.dart';
+
+class UserAccountScreen extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+    // 상태 읽기
+    final userState = ref.watch(userAccountProvider);
+
+    return PopScope<Object?>(
+      canPop: false, // 뒤로 가기 제스처 및 버튼을 막음
+      onPopInvokedWithResult: (bool didPop, Object? result) {
+        // 뒤로 가기 동작을 하지 않도록 막음 (아무 동작도 하지 않음)
+      },
+      child: Scaffold(
+        backgroundColor: Colors.white,
+        body: SafeArea(
+          child: userState.when(
+            loading: () => Center(child: CircularProgressIndicator()),
+            error: (error, stackTrace) =>
+                Center(child: Text('오류 발생: $error')), // 에러 상태
+            data: (user) => Column(
+              children: [
+                _buildProfileSection(user, screenWidth, screenHeight),
+                SizedBox(height: screenHeight * 0.15), // 프로필 섹션 아래 여백
+                Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.05),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _buildDetailsSection(context, user, screenWidth, screenHeight),
+                        SizedBox(height: screenHeight * 0.02),
+                        Divider(thickness: screenHeight * 0.001, color: Colors.grey[300]),
+                        SizedBox(height: screenHeight * 0.02),
+                        _buildPasswordChangeSection(context, user, screenWidth, screenHeight),
+                        Divider(thickness: screenHeight * 0.001, color: Colors.grey[300]),
+                      ],
+                    ),
+                  ),
+                ),
+                _buildLogoutButton(context, ref, screenWidth, screenHeight),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // 프로필 섹션
+  Widget _buildProfileSection(dynamic user, double screenWidth, double screenHeight) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Container(
+          width: double.infinity,
+          height: screenHeight * 0.3,
+          color: const Color(0xFFE3E8EF), // 배경색 설정
+        ),
+        Positioned(
+          bottom: -(screenHeight * 0.1),
+          left: (screenWidth - screenHeight * 0.2) / 2,
+          child: Column(
+            children: [
+              CircleAvatar(
+                radius: screenHeight * 0.1,
+                backgroundColor: const Color(0xFF4A6FA5),
+                backgroundImage: user.profilePicUrl != null
+                    ? NetworkImage(user.profilePicUrl!)
+                    : null,
+                child: user.profilePicUrl == null
+                    ? Icon(
+                        Icons.person,
+                        size: screenHeight * 0.08,
+                        color: Colors.white,
+                      )
+                    : null,
+              ),
+              SizedBox(height: screenHeight * 0.02),
+              Text(
+                user.name,
+                style: TextStyle(
+                  fontSize: screenWidth * 0.06,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  // 상세 정보 섹션
+  Widget _buildDetailsSection(BuildContext context, dynamic user, double screenWidth, double screenHeight) {
+    return Column(
+      children: [
+        GestureDetector(
+          onTap: () {
+            Navigator.pushNamed(context, '/updatePubid'); // 매장 선택 화면 이동
+          },
+          child: _buildInfoRow(
+            title: 'ご利用店舗名',
+            value: user.pubId ?? '未登録',
+            isLongText: true,
+            screenWidth: screenWidth,
+            showIcon: true,
+          ),
+        ),
+        _buildInfoRow(
+          title: 'メールアドレス',
+          value: user.email,
+          isLongText: true,
+          screenWidth: screenWidth,
+          showIcon: false,
+        ),
+      ],
+    );
+  }
+
+  // 정보 행 위젯
+  Widget _buildInfoRow({
+    required String title,
+    required String value,
+    required bool isLongText,
+    required double screenWidth,
+    required bool showIcon,
+  }) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: screenWidth * 0.04,
+            color: const Color.fromARGB(255, 145, 163, 189),
+          ),
+        ),
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: Padding(
+              padding: EdgeInsets.only(right: screenWidth * 0.05),
+              child: isLongText && value.length > 20
+                  ? Text.rich(
+                      TextSpan(
+                        children: [
+                          TextSpan(text: value.substring(0, 18)),
+                          TextSpan(text: '\n${value.substring(18)}'),
+                        ],
+                      ),
+                      style: TextStyle(
+                        fontSize: screenWidth * 0.04,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.right,
+                    )
+                  : Text(
+                      value,
+                      style: TextStyle(
+                        fontSize: screenWidth * 0.04,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+            ),
+          ),
+        ),
+        if (showIcon)
+          Icon(
+            Icons.arrow_forward_ios,
+            size: screenWidth * 0.04,
+            color: Colors.grey,
+          ),
+      ],
+    );
+  }
+
+  // 비밀번호 변경 섹션
+  Widget _buildPasswordChangeSection(BuildContext context, dynamic user, double screenWidth, double screenHeight) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: () {
+        if (user.authType == 'google') {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('해당 아이디는 비밀번호 변경이 불가합니다.'),
+            ),
+          );
+        } else {
+          Navigator.pushNamed(context, '/verifyPassword');
+        }
+      },
+      child: Container(
+        padding: EdgeInsets.symmetric(vertical: screenHeight * 0.02),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'パスワード変更',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: screenWidth * 0.04,
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              size: screenWidth * 0.04,
+              color: Colors.grey,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // 로그아웃 버튼
+  Widget _buildLogoutButton(BuildContext context, WidgetRef ref, double screenWidth, double screenHeight) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: screenWidth * 0.05,
+        vertical: screenHeight * 0.02,
+      ),
+      child: OutlinedButton(
+        onPressed: () async {
+          final authService = AuthService();
+          await authService.logout(context, ref); // 로그아웃 처리
+          Navigator.of(context, rootNavigator: true).pushReplacementNamed('/first'); // 첫 화면으로 이동
+        },
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(
+            color: Colors.black,
+            width: screenWidth * 0.005,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(screenWidth * 0.1),
+          ),
+          padding: EdgeInsets.symmetric(
+            vertical: screenHeight * 0.015,
+          ),
+          minimumSize: Size(screenWidth, screenHeight * 0.05),
+        ),
+        child: Text(
+          'ログアウト',
+          style: TextStyle(
+            fontSize: screenWidth * 0.04,
+            fontWeight: FontWeight.bold,
+            color: Colors.black,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/tab/user/user_home_screen.dart
+++ b/lib/view/tab/user/user_home_screen.dart
@@ -8,6 +8,9 @@ import 'user_transfer_screen.dart'; // 유저 포인트 거래 화면
 import 'user_transfer_confirm_screen.dart'; // 유저 포인트 거래 확인 화면
 import 'user_transaction_history_screen.dart';
 import '../event_home.dart';
+import 'user_account_screen.dart';
+import 'verify_password_screen.dart'; // 비밀번호 확인 화면 추가
+import 'update_pubid_screen.dart';
 
 // UserHomeScreen 클래스는 ConsumerWidget을 사용하여 상태 관리
 class UserHomeScreen extends ConsumerWidget {
@@ -21,7 +24,7 @@ class UserHomeScreen extends ConsumerWidget {
       EventPageView(),
       UserTransactionHistoryScreen(),
       QrTabNavigator(), // QR 코드 스캔 및 포인트 관리 페이지
-      AccountTab(),
+      UserAccountNavigator(), // UserAccountNavigator로 교체
       UserSettingsTab(),
     ];
 
@@ -96,11 +99,27 @@ class QrTabNavigator extends StatelessWidget {
   }
 }
 
-class AccountTab extends StatelessWidget {
+// UserAccountScreen을 위한 Navigator
+class UserAccountNavigator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text('アカウント'),
+    return Navigator(
+      onGenerateRoute: (settings) {
+        switch (settings.name) {
+          case '/verifyPassword': // VerifyPasswordScreen으로 이동하는 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => VerifyPasswordScreen(),
+            );
+          case '/updatePubid':
+            return MaterialPageRoute(
+              builder: (context) => UpdatePubIdScreen(),
+            );
+          default:
+            return MaterialPageRoute(
+              builder: (context) => UserAccountScreen(), // 기본 UserAccountScreen
+            );
+        }
+      },
     );
   }
 }

--- a/lib/view/tab/user/verify_password_screen.dart
+++ b/lib/view/tab/user/verify_password_screen.dart
@@ -169,6 +169,17 @@ class SubmitButtonSection extends StatelessWidget {
         onPressed: () async {
           final password = passwordController.text;
 
+          // 입력 필드가 비어 있는 경우 경고 메시지 표시
+          if (password.isEmpty) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('パスワードを入力してください。'), // 비밀번호를 입력해 주세요.
+                backgroundColor: Colors.red,
+              ),
+            );
+            return;
+          }
+          
           // 비밀번호 인증 요청
           final isValid = await ref
               .read(userAccountProvider.notifier)

--- a/lib/view/tab/user/verify_password_screen.dart
+++ b/lib/view/tab/user/verify_password_screen.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../viewModel/user_account_view_model.dart';
+import 'user_account_screen.dart';
+
+class VerifyPasswordScreen extends ConsumerStatefulWidget {
+  @override
+  _VerifyPasswordScreenState createState() => _VerifyPasswordScreenState();
+}
+
+class _VerifyPasswordScreenState extends ConsumerState<VerifyPasswordScreen> {
+  final TextEditingController passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    passwordController.dispose(); // 컨트롤러 해제
+    super.dispose();
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(height: screenHeight * 0.05),
+            HeaderSection(screenHeight: screenHeight, screenWidth: screenWidth),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.08),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(height: screenHeight * 0.08),
+                  InstructionSection(screenWidth: screenWidth),
+                  SizedBox(height: screenHeight * 0.05),
+                  PasswordInputSection(
+                    passwordController: passwordController,
+                    screenWidth: screenWidth,
+                  ),
+                  SizedBox(height: screenHeight * 0.05),
+                  SubmitButtonSection(
+                    passwordController: passwordController,
+                    screenHeight: screenHeight,
+                    screenWidth: screenWidth,
+                    ref: ref,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class HeaderSection extends StatelessWidget {
+  final double screenHeight;
+  final double screenWidth;
+
+  const HeaderSection({
+    required this.screenHeight,
+    required this.screenWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: screenWidth * 0.05,
+        top: screenHeight * 0.03,
+      ),
+      child: Text(
+        'パスワード確認', // 일본어로 비밀번호 확인
+        style: TextStyle(
+          fontSize: screenWidth * 0.06,
+          fontWeight: FontWeight.bold,
+          color: Colors.black,
+        ),
+      ),
+    );
+  }
+}
+
+class InstructionSection extends StatelessWidget {
+  final double screenWidth;
+
+  const InstructionSection({
+    required this.screenWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        '現在のパスワードを入力してください',
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: screenWidth * 0.05,
+          fontWeight: FontWeight.bold,
+          color: Colors.black,
+        ),
+      ),
+    );
+  }
+}
+
+class PasswordInputSection extends StatelessWidget {
+  final TextEditingController passwordController;
+  final double screenWidth;
+
+  const PasswordInputSection({
+    required this.passwordController,
+    required this.screenWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: passwordController,
+      obscureText: true,
+      decoration: InputDecoration(
+        labelText: '現在のパスワード',
+        labelStyle: TextStyle(
+          fontSize: screenWidth * 0.045,
+          color: Colors.grey,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(
+            color: const Color(0xFF4A6FA5),
+            width: 2,
+          ),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(
+            color: const Color(0xFF4A6FA5),
+            width: 2,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SubmitButtonSection extends StatelessWidget {
+  final TextEditingController passwordController;
+  final double screenHeight;
+  final double screenWidth;
+  final WidgetRef ref;
+
+  const SubmitButtonSection({
+    required this.passwordController,
+    required this.screenHeight,
+    required this.screenWidth,
+    required this.ref,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: () async {
+          final password = passwordController.text;
+
+          // 비밀번호 인증 요청
+          final isValid = await ref
+              .read(userAccountProvider.notifier)
+              .validatePassword(password);
+
+          if (isValid) {
+            // 성공 시 비밀번호 재설정 화면으로 이동
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(builder: (context) => UserAccountScreen()),
+            );
+          } else {
+            // 실패 시 에러 메시지 표시
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('パスワードが一致しません。'),
+                backgroundColor: Colors.red,
+              ),
+            );
+          }
+        },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF4A6FA5),
+          foregroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(40),
+          ),
+          padding: EdgeInsets.symmetric(
+            vertical: screenHeight * 0.02,
+            horizontal: screenWidth * 0.3,
+          ),
+        ),
+        child: Text(
+          '確認',
+          style: TextStyle(
+            fontSize: screenWidth * 0.045,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/viewModel/user_account_view_model.dart
+++ b/lib/viewModel/user_account_view_model.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
+import '../model/user_model.dart';
+import '../services/preferences_manager.dart';
+
+class UserAccountViewModel extends StateNotifier<AsyncValue<User>> {
+  UserAccountViewModel() : super(const AsyncValue.loading()); // 초기 상태 설정
+
+  
+  Future<void> fetchUserData() async {
+    state = const AsyncValue.loading(); // 상태를 로딩 상태로 설정
+
+    try {
+      // 1. PreferencesManager에서 이메일 가져오기
+      final email = await PreferencesManager.instance.getEmail();
+
+      if (email == null) {
+        throw Exception('이메일이 설정되지 않았습니다.'); // 이메일이 없으면 예외 발생
+      }
+
+      // 2. Firestore에서 이메일로 사용자 문서 조회
+      final userDoc = await FirebaseFirestore.instance
+          .collection('users')
+          .where('email', isEqualTo: email)
+          .get();
+
+      if (userDoc.docs.isEmpty) {
+        throw Exception('사용자 정보를 찾을 수 없습니다.'); // 조회된 문서가 없으면 예외 발생
+      }
+
+      // 3. Firestore 데이터를 User 모델로 변환
+      final userData = userDoc.docs.first.data();
+      final user = User.fromJson({...userData, 'uid': userDoc.docs.first.id});
+
+      state = AsyncValue.data(user); // 상태를 조회된 사용자 데이터로 설정
+    } catch (e, stackTrace) {
+      state = AsyncValue.error(e, stackTrace); // 상태를 에러로 설정
+    }
+  }
+
+  //현재 사용자 이메일로 비밀번호 재설정 이메일을 보냅니다.
+  Future<void> sendPasswordResetEmail() async {
+    try {
+      final user = state.value; // 현재 상태에서 사용자 데이터를 가져옵니다.
+
+      if (user == null || user.email.isEmpty) {
+        throw Exception('사용자의 이메일 정보를 확인할 수 없습니다.');
+      }
+
+      // Firebase Authentication을 사용하여 비밀번호 재설정 이메일 전송
+      await firebase_auth.FirebaseAuth.instance
+          .sendPasswordResetEmail(email: user.email);
+
+      print('비밀번호 재설정 이메일이 발송되었습니다.'); // 성공 로그
+    } catch (e) {
+      print('비밀번호 재설정 이메일 발송 중 오류가 발생했습니다: $e');
+      throw Exception('비밀번호 재설정 이메일 발송 실패: $e'); // 실패 시 예외 발생
+    }
+  }
+  
+  //사용자 패스워드를 재인증합니다.
+  Future<bool> validatePassword(String password) async {
+    try {
+      final user = state.value; // 현재 상태에서 사용자 데이터를 가져옵니다.
+
+      if (user == null || user.email.isEmpty) {
+        throw Exception('사용자의 이메일 정보를 확인할 수 없습니다.');
+      }
+
+      // 1. 현재 로그인된 사용자 가져오기
+      final currentUser = firebase_auth.FirebaseAuth.instance.currentUser;
+
+      if (currentUser == null) {
+        throw Exception('현재 로그인된 사용자를 찾을 수 없습니다.');
+      }
+
+      // 2. 이메일과 비밀번호로 자격 증명 생성
+      final credential = firebase_auth.EmailAuthProvider.credential(
+        email: user.email,
+        password: password,
+      );
+
+      // 3. Firebase Authentication에서 재인증
+      await currentUser.reauthenticateWithCredential(credential);
+
+      // 4. 비밀번호 재설정 이메일 전송
+      await sendPasswordResetEmail();
+
+      print('비밀번호 인증 성공'); // 성공 로그
+      return true;
+    } catch (e) {
+      print('비밀번호 인증 실패: $e'); // 실패 로그
+      return false;
+    }
+  }
+
+  void updatePubId(String newPubId) {
+    final user = state.value; // 현재 상태에서 사용자 데이터를 가져옵니다.
+    if (user != null) {
+      // 기존 User 객체를 복사하여 pubId 업데이트
+      final updatedUser = user.copyWith(pubId: newPubId);
+      state = AsyncValue.data(updatedUser); // 상태를 업데이트된 User로 설정
+      print('User pubId가 업데이트되었습니다: $newPubId'); // 성공 로그
+    }
+  }
+}
+
+
+final userAccountProvider =
+    StateNotifierProvider<UserAccountViewModel, AsyncValue<User>>((ref) {
+  final viewModel = UserAccountViewModel();
+  viewModel.fetchUserData(); // 초기화 시 사용자 데이터 조회
+  return viewModel;
+});

--- a/lib/viewModel/user_update_pubid_view_model.dart
+++ b/lib/viewModel/user_update_pubid_view_model.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 상태 클래스
+/// - `stores`: 전체 매장 이름 리스트
+/// - `filteredStores`: 필터링된 매장 이름 리스트
+/// - `selectedStore`: 선택된 매장 이름
+class UserUpdatePubIdState {
+  final List<String> stores;
+  final List<String> filteredStores;
+  final String? selectedStore;
+
+  UserUpdatePubIdState({
+    this.stores = const [],
+    this.filteredStores = const [],
+    this.selectedStore,
+  });
+
+  /// 상태 복사 메서드
+  UserUpdatePubIdState copyWith({
+    List<String>? stores,
+    List<String>? filteredStores,
+    String? selectedStore,
+  }) {
+    return UserUpdatePubIdState(
+      stores: stores ?? this.stores,
+      filteredStores: filteredStores ?? this.filteredStores,
+      selectedStore: selectedStore ?? this.selectedStore,
+    );
+  }
+}
+
+class UpdatePubIdViewModel extends StateNotifier<UserUpdatePubIdState> {
+  UpdatePubIdViewModel() : super(UserUpdatePubIdState());
+
+
+  Future<void> fetchStoresFromFirestore() async {
+    try {
+      final querySnapshot = await FirebaseFirestore.instance.collection('owners').get();
+
+      // storeName 필드를 추출하여 리스트로 변환
+      final storeNames = querySnapshot.docs
+          .map((doc) => doc['storeName'] as String)
+          .toList();
+
+      // 상태 업데이트
+      state = state.copyWith(
+        stores: storeNames,
+        filteredStores: storeNames,
+      );
+    } catch (e) {
+      print('Firestore 데이터를 가져오는 중 오류 발생: $e');
+    }
+  }
+
+  void filterStores(String query) {
+    if (query.isEmpty) {
+      // 검색어가 비어 있으면 전체 데이터를 반환
+      state = state.copyWith(filteredStores: state.stores);
+      return;
+    }
+
+    // 검색어가 포함된 매장 이름만 필터링
+    final filtered = state.stores.where((storeName) {
+      return storeName.toLowerCase().contains(query.toLowerCase());
+    }).toList();
+
+    // 상태 업데이트
+    state = state.copyWith(filteredStores: filtered);
+  }
+
+  // 사용자가 선택한 매장 이름을 `selectedStore` 상태에 저장합니다.
+  void updateSelectedStore(String storeName) {
+    state = state.copyWith(selectedStore: storeName);
+  }
+
+  Future<bool> updateSelectedStoreAndPubId(String storeName) async {
+    try {
+      updateSelectedStore(storeName); // 1. 상태 업데이트
+
+      final prefs = await SharedPreferences.getInstance(); // 2. SharedPreferences에서 이메일 가져오기
+      final email = prefs.getString('email');
+
+      if (email == null) {
+        print('SharedPreferences에서 이메일을 찾을 수 없습니다.');
+        return false;
+      }
+
+      // 3. Firestore에서 이메일로 사용자 문서 찾기
+      final querySnapshot = await FirebaseFirestore.instance
+          .collection('users')
+          .where('email', isEqualTo: email)
+          .get();
+
+      if (querySnapshot.docs.isNotEmpty) {
+        final docId = querySnapshot.docs.first.id; // 첫 번째 문서 ID 가져오기
+
+        // 4. Firestore에서 pubId 필드를 업데이트
+        await FirebaseFirestore.instance
+            .collection('users')
+            .doc(docId)
+            .update({'pubId': storeName});
+
+        print('pubId가 $storeName로 업데이트되었습니다.');
+        return true; 
+      } else {
+        print('users 컬렉션에서 해당 이메일을 찾을 수 없습니다.');
+        return false; 
+      }
+    } catch (e) {
+      print('pubId 업데이트 중 오류 발생: $e');
+      return false; 
+    }
+  }
+}
+
+final updatePubIdViewModelProvider =
+    StateNotifierProvider<UpdatePubIdViewModel, UserUpdatePubIdState>((ref) {
+  return UpdatePubIdViewModel();
+});

--- a/lib/viewModel/user_update_pubid_view_model.dart
+++ b/lib/viewModel/user_update_pubid_view_model.dart
@@ -55,20 +55,15 @@ class UpdatePubIdViewModel extends StateNotifier<UserUpdatePubIdState> {
   }
 
   void filterStores(String query) {
-    if (query.isEmpty) {
-      // 검색어가 비어 있으면 전체 데이터를 반환
-      state = state.copyWith(filteredStores: state.stores);
-      return;
-    }
-
-    // 검색어가 포함된 매장 이름만 필터링
-    final filtered = state.stores.where((storeName) {
-      return storeName.toLowerCase().contains(query.toLowerCase());
-    }).toList();
+    // 검색어가 비어 있는지 확인 후 필터링
+    final filtered = query.isEmpty
+        ? state.stores
+        : state.stores.where((storeName) => storeName.toLowerCase().contains(query.toLowerCase())).toList();
 
     // 상태 업데이트
     state = state.copyWith(filteredStores: filtered);
   }
+
 
   // 사용자가 선택한 매장 이름을 `selectedStore` 상태에 저장합니다.
   void updateSelectedStore(String storeName) {


### PR DESCRIPTION
lib/model/store_model.dart: 가게 모델입니다.

lib/services/auth_service.dart: 로그아웃 기능을 여기로 옮겼습니다.

lib/view/tab/user/update_pubid_screen.dart: 가게를 선택하는 화면입니다.

lib/view/tab/user/user_account_screen.dart: 회원정보 화면입니다. 1. 가게를 선택하고 2. 비밀번호를 변경 3. 로그아웃 기능이 있습니다.

lib/view/tab/user/user_home_screen.dart: user_account_screen을 추가하였습니다.

lib/view/tab/user/verify_password_screen.dart: 비밀번호 변경시 회원의 현재 비밀번호를 입력받고 비밀번호 변경 이메일을 보내도록 구현하였습니다.

lib/viewModel/user_account_view_model.dart: user_account_screen.dart과 verify_password_screen.dart의 viewmodel입니다.

lib/viewModel/user_update_pubid_view_model.dart: update_pubid_screen.dart의 viewmodel입니다.