### PR TITLE
owner회원가입시 point 제한 추가 및 owner user 설정탭 구현

### DIFF
--- a/lib/model/owner_model.dart
+++ b/lib/model/owner_model.dart
@@ -1,91 +1,23 @@
-class Owner {
-  final String uid;         // 고유 ID
-  final String storeName;   // 점포명
-  final String email;       // 이메일 주소
-  final String zipCode;     // 우편번호
-  final String prefecture;  // 도도부현 (도/도/부/현)
-  final String city;        // 시/구/읍/면/동
-  final String address;     // 상세 주소
-  final String? building;   // 건물명, 호실 번호 (선택사항)
-  final String authType;    // 인증 유형 (기본값: 'email')
-  final String type;        // 사용자 유형 (기본값: 'owner')
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-  // 생성자
-  Owner({
-    required this.uid,
-    required this.storeName,
-    required this.email,
-    required this.zipCode,
-    required this.prefecture,
-    required this.city,
-    required this.address,
-    this.building,  // 선택사항
-    this.authType = 'email', // 기본값으로 'email' 설정
-    this.type = 'owner',     // 기본값으로 'owner' 설정
-  });
+part 'owner_model.freezed.dart';
+part 'owner_model.g.dart';
 
-  // Firestore에 저장할 데이터를 Map 형태로 변환하는 메서드
-  Map<String, dynamic> toMap() {
-    final Map<String, dynamic> data = {
-      'uid': uid,
-      'storeName': storeName,
-      'email': email,
-      'zipCode': zipCode,
-      'prefecture': prefecture,
-      'city': city,
-      'address': address,
-      'authType': authType, // authType 추가
-      'type': type,         // type 추가
-    };
+@freezed
+class Owner with _$Owner {
+  const factory Owner({
+    required String uid,             // 고유 ID
+    required String storeName,       // 점포명
+    required String email,           // 이메일 주소
+    required String zipCode,         // 우편번호
+    required String prefecture,      // 도도부현
+    required String city,            // 시/구/읍/면/동
+    required String address,         // 상세 주소
+    String? building,                // 건물명 (선택사항)
+    @Default('email') String authType, // 인증 유형
+    @Default('owner') String type,     // 사용자 유형
+    @Default(100000) int pointLimit,   // 포인트 제한
+  }) = _Owner;
 
-    // building이 null일 경우 저장하지 않음
-    if (building != null && building!.isNotEmpty) {
-      data['building'] = building;
-    }
-
-    return data;
-  }
-
-  // Firestore에서 데이터를 가져와 Owner 객체로 변환하는 팩토리 메서드
-  factory Owner.fromMap(Map<String, dynamic> map) {
-    return Owner(
-      uid: map['uid'] as String,
-      storeName: map['storeName'] as String,
-      email: map['email'] as String,
-      zipCode: map['zipCode'] as String,
-      prefecture: map['prefecture'] as String,
-      city: map['city'] as String,
-      address: map['address'] as String,
-      building: map['building'] as String?, // building이 있을 때만 매핑
-      authType: map['authType'] as String? ?? 'email', // 기본값 'email'
-      type: map['type'] as String? ?? 'owner',         // 기본값 'owner'
-    );
-  }
-
-  // Owner 객체 복사본을 생성하는 copyWith 메서드
-  Owner copyWith({
-    String? uid,
-    String? storeName,
-    String? email,
-    String? zipCode,
-    String? prefecture,
-    String? city,
-    String? address,
-    String? building,
-    String? authType,
-    String? type,
-  }) {
-    return Owner(
-      uid: uid ?? this.uid,
-      storeName: storeName ?? this.storeName,
-      email: email ?? this.email,
-      zipCode: zipCode ?? this.zipCode,
-      prefecture: prefecture ?? this.prefecture,
-      city: city ?? this.city,
-      address: address ?? this.address,
-      building: building ?? this.building,  // building이 null이면 유지
-      authType: authType ?? this.authType,  // authType 추가
-      type: type ?? this.type,              // type 추가
-    );
-  }
+  factory Owner.fromJson(Map<String, dynamic> json) => _$OwnerFromJson(json);
 }

--- a/lib/model/owner_model.freezed.dart
+++ b/lib/model/owner_model.freezed.dart
@@ -1,0 +1,383 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'owner_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Owner _$OwnerFromJson(Map<String, dynamic> json) {
+  return _Owner.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Owner {
+  String get uid => throw _privateConstructorUsedError; // 고유 ID
+  String get storeName => throw _privateConstructorUsedError; // 점포명
+  String get email => throw _privateConstructorUsedError; // 이메일 주소
+  String get zipCode => throw _privateConstructorUsedError; // 우편번호
+  String get prefecture => throw _privateConstructorUsedError; // 도도부현
+  String get city => throw _privateConstructorUsedError; // 시/구/읍/면/동
+  String get address => throw _privateConstructorUsedError; // 상세 주소
+  String? get building => throw _privateConstructorUsedError; // 건물명 (선택사항)
+  String get authType => throw _privateConstructorUsedError; // 인증 유형
+  String get type => throw _privateConstructorUsedError; // 사용자 유형
+  int get pointLimit => throw _privateConstructorUsedError;
+
+  /// Serializes this Owner to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Owner
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $OwnerCopyWith<Owner> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $OwnerCopyWith<$Res> {
+  factory $OwnerCopyWith(Owner value, $Res Function(Owner) then) =
+      _$OwnerCopyWithImpl<$Res, Owner>;
+  @useResult
+  $Res call(
+      {String uid,
+      String storeName,
+      String email,
+      String zipCode,
+      String prefecture,
+      String city,
+      String address,
+      String? building,
+      String authType,
+      String type,
+      int pointLimit});
+}
+
+/// @nodoc
+class _$OwnerCopyWithImpl<$Res, $Val extends Owner>
+    implements $OwnerCopyWith<$Res> {
+  _$OwnerCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Owner
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? uid = null,
+    Object? storeName = null,
+    Object? email = null,
+    Object? zipCode = null,
+    Object? prefecture = null,
+    Object? city = null,
+    Object? address = null,
+    Object? building = freezed,
+    Object? authType = null,
+    Object? type = null,
+    Object? pointLimit = null,
+  }) {
+    return _then(_value.copyWith(
+      uid: null == uid
+          ? _value.uid
+          : uid // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeName: null == storeName
+          ? _value.storeName
+          : storeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      zipCode: null == zipCode
+          ? _value.zipCode
+          : zipCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      prefecture: null == prefecture
+          ? _value.prefecture
+          : prefecture // ignore: cast_nullable_to_non_nullable
+              as String,
+      city: null == city
+          ? _value.city
+          : city // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      building: freezed == building
+          ? _value.building
+          : building // ignore: cast_nullable_to_non_nullable
+              as String?,
+      authType: null == authType
+          ? _value.authType
+          : authType // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+      pointLimit: null == pointLimit
+          ? _value.pointLimit
+          : pointLimit // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$OwnerImplCopyWith<$Res> implements $OwnerCopyWith<$Res> {
+  factory _$$OwnerImplCopyWith(
+          _$OwnerImpl value, $Res Function(_$OwnerImpl) then) =
+      __$$OwnerImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String uid,
+      String storeName,
+      String email,
+      String zipCode,
+      String prefecture,
+      String city,
+      String address,
+      String? building,
+      String authType,
+      String type,
+      int pointLimit});
+}
+
+/// @nodoc
+class __$$OwnerImplCopyWithImpl<$Res>
+    extends _$OwnerCopyWithImpl<$Res, _$OwnerImpl>
+    implements _$$OwnerImplCopyWith<$Res> {
+  __$$OwnerImplCopyWithImpl(
+      _$OwnerImpl _value, $Res Function(_$OwnerImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Owner
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? uid = null,
+    Object? storeName = null,
+    Object? email = null,
+    Object? zipCode = null,
+    Object? prefecture = null,
+    Object? city = null,
+    Object? address = null,
+    Object? building = freezed,
+    Object? authType = null,
+    Object? type = null,
+    Object? pointLimit = null,
+  }) {
+    return _then(_$OwnerImpl(
+      uid: null == uid
+          ? _value.uid
+          : uid // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeName: null == storeName
+          ? _value.storeName
+          : storeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      zipCode: null == zipCode
+          ? _value.zipCode
+          : zipCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      prefecture: null == prefecture
+          ? _value.prefecture
+          : prefecture // ignore: cast_nullable_to_non_nullable
+              as String,
+      city: null == city
+          ? _value.city
+          : city // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      building: freezed == building
+          ? _value.building
+          : building // ignore: cast_nullable_to_non_nullable
+              as String?,
+      authType: null == authType
+          ? _value.authType
+          : authType // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+      pointLimit: null == pointLimit
+          ? _value.pointLimit
+          : pointLimit // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$OwnerImpl implements _Owner {
+  const _$OwnerImpl(
+      {required this.uid,
+      required this.storeName,
+      required this.email,
+      required this.zipCode,
+      required this.prefecture,
+      required this.city,
+      required this.address,
+      this.building,
+      this.authType = 'email',
+      this.type = 'owner',
+      this.pointLimit = 100000});
+
+  factory _$OwnerImpl.fromJson(Map<String, dynamic> json) =>
+      _$$OwnerImplFromJson(json);
+
+  @override
+  final String uid;
+// 고유 ID
+  @override
+  final String storeName;
+// 점포명
+  @override
+  final String email;
+// 이메일 주소
+  @override
+  final String zipCode;
+// 우편번호
+  @override
+  final String prefecture;
+// 도도부현
+  @override
+  final String city;
+// 시/구/읍/면/동
+  @override
+  final String address;
+// 상세 주소
+  @override
+  final String? building;
+// 건물명 (선택사항)
+  @override
+  @JsonKey()
+  final String authType;
+// 인증 유형
+  @override
+  @JsonKey()
+  final String type;
+// 사용자 유형
+  @override
+  @JsonKey()
+  final int pointLimit;
+
+  @override
+  String toString() {
+    return 'Owner(uid: $uid, storeName: $storeName, email: $email, zipCode: $zipCode, prefecture: $prefecture, city: $city, address: $address, building: $building, authType: $authType, type: $type, pointLimit: $pointLimit)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OwnerImpl &&
+            (identical(other.uid, uid) || other.uid == uid) &&
+            (identical(other.storeName, storeName) ||
+                other.storeName == storeName) &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.zipCode, zipCode) || other.zipCode == zipCode) &&
+            (identical(other.prefecture, prefecture) ||
+                other.prefecture == prefecture) &&
+            (identical(other.city, city) || other.city == city) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.building, building) ||
+                other.building == building) &&
+            (identical(other.authType, authType) ||
+                other.authType == authType) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.pointLimit, pointLimit) ||
+                other.pointLimit == pointLimit));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, uid, storeName, email, zipCode,
+      prefecture, city, address, building, authType, type, pointLimit);
+
+  /// Create a copy of Owner
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OwnerImplCopyWith<_$OwnerImpl> get copyWith =>
+      __$$OwnerImplCopyWithImpl<_$OwnerImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$OwnerImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Owner implements Owner {
+  const factory _Owner(
+      {required final String uid,
+      required final String storeName,
+      required final String email,
+      required final String zipCode,
+      required final String prefecture,
+      required final String city,
+      required final String address,
+      final String? building,
+      final String authType,
+      final String type,
+      final int pointLimit}) = _$OwnerImpl;
+
+  factory _Owner.fromJson(Map<String, dynamic> json) = _$OwnerImpl.fromJson;
+
+  @override
+  String get uid; // 고유 ID
+  @override
+  String get storeName; // 점포명
+  @override
+  String get email; // 이메일 주소
+  @override
+  String get zipCode; // 우편번호
+  @override
+  String get prefecture; // 도도부현
+  @override
+  String get city; // 시/구/읍/면/동
+  @override
+  String get address; // 상세 주소
+  @override
+  String? get building; // 건물명 (선택사항)
+  @override
+  String get authType; // 인증 유형
+  @override
+  String get type; // 사용자 유형
+  @override
+  int get pointLimit;
+
+  /// Create a copy of Owner
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$OwnerImplCopyWith<_$OwnerImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/owner_model.g.dart
+++ b/lib/model/owner_model.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'owner_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$OwnerImpl _$$OwnerImplFromJson(Map<String, dynamic> json) => _$OwnerImpl(
+      uid: json['uid'] as String,
+      storeName: json['storeName'] as String,
+      email: json['email'] as String,
+      zipCode: json['zipCode'] as String,
+      prefecture: json['prefecture'] as String,
+      city: json['city'] as String,
+      address: json['address'] as String,
+      building: json['building'] as String?,
+      authType: json['authType'] as String? ?? 'email',
+      type: json['type'] as String? ?? 'owner',
+      pointLimit: (json['pointLimit'] as num?)?.toInt() ?? 100000,
+    );
+
+Map<String, dynamic> _$$OwnerImplToJson(_$OwnerImpl instance) =>
+    <String, dynamic>{
+      'uid': instance.uid,
+      'storeName': instance.storeName,
+      'email': instance.email,
+      'zipCode': instance.zipCode,
+      'prefecture': instance.prefecture,
+      'city': instance.city,
+      'address': instance.address,
+      'building': instance.building,
+      'authType': instance.authType,
+      'type': instance.type,
+      'pointLimit': instance.pointLimit,
+    };

--- a/lib/model/owner_signup_state_model.dart
+++ b/lib/model/owner_signup_state_model.dart
@@ -1,0 +1,53 @@
+// owner_signup_state_model.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'owner_model.dart';
+
+part 'owner_signup_state_model.freezed.dart';
+part 'owner_signup_state_model.g.dart'; // JSON 직렬화를 사용할 경우 추가
+
+@freezed
+class OwnerSignUpState with _$OwnerSignUpState {
+  const factory OwnerSignUpState({
+    @Default('') String storeName,
+    @Default('') String email,
+    @Default('') String password,
+    @Default('') String confirmPassword,
+    @Default('') String zipCode,
+    @Default('') String state,
+    @Default('') String city,
+    @Default('') String address,
+    String? building,
+    String? emailError,
+    String? passwordError,
+    String? confirmPasswordError,
+    String? verificationErrorMessage,
+    @Default(false) bool isPasswordVisible,
+    @Default(false) bool isConfirmPasswordVisible,
+    @Default(false) bool isLoading,
+    String? verificationCode,
+    Owner? owner,
+    @Default(false) bool signUpSuccess,
+    String? signUpError,
+    @Default(false) bool verificationSuccess,
+    @Default(false) bool resendCodeSuccess,
+    String? resendCodeError,
+  }) = _OwnerSignUpState;
+
+  factory OwnerSignUpState.fromJson(Map<String, dynamic> json) =>
+      _$OwnerSignUpStateFromJson(json);
+}
+
+extension OwnerSignUpStateExtension on OwnerSignUpState {
+  bool get isFormValid =>
+      storeName.isNotEmpty &&
+      email.isNotEmpty &&
+      password.isNotEmpty &&
+      confirmPassword.isNotEmpty &&
+      zipCode.isNotEmpty &&
+      state.isNotEmpty &&
+      city.isNotEmpty &&
+      address.isNotEmpty &&
+      emailError == null &&
+      passwordError == null &&
+      confirmPasswordError == null;
+}

--- a/lib/model/owner_signup_state_model.freezed.dart
+++ b/lib/model/owner_signup_state_model.freezed.dart
@@ -1,0 +1,686 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'owner_signup_state_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+OwnerSignUpState _$OwnerSignUpStateFromJson(Map<String, dynamic> json) {
+  return _OwnerSignUpState.fromJson(json);
+}
+
+/// @nodoc
+mixin _$OwnerSignUpState {
+  String get storeName => throw _privateConstructorUsedError;
+  String get email => throw _privateConstructorUsedError;
+  String get password => throw _privateConstructorUsedError;
+  String get confirmPassword => throw _privateConstructorUsedError;
+  String get zipCode => throw _privateConstructorUsedError;
+  String get state => throw _privateConstructorUsedError;
+  String get city => throw _privateConstructorUsedError;
+  String get address => throw _privateConstructorUsedError;
+  String? get building => throw _privateConstructorUsedError;
+  String? get emailError => throw _privateConstructorUsedError;
+  String? get passwordError => throw _privateConstructorUsedError;
+  String? get confirmPasswordError => throw _privateConstructorUsedError;
+  String? get verificationErrorMessage => throw _privateConstructorUsedError;
+  bool get isPasswordVisible => throw _privateConstructorUsedError;
+  bool get isConfirmPasswordVisible => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+  String? get verificationCode => throw _privateConstructorUsedError;
+  Owner? get owner => throw _privateConstructorUsedError;
+  bool get signUpSuccess => throw _privateConstructorUsedError;
+  String? get signUpError => throw _privateConstructorUsedError;
+  bool get verificationSuccess => throw _privateConstructorUsedError;
+  bool get resendCodeSuccess => throw _privateConstructorUsedError;
+  String? get resendCodeError => throw _privateConstructorUsedError;
+
+  /// Serializes this OwnerSignUpState to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of OwnerSignUpState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $OwnerSignUpStateCopyWith<OwnerSignUpState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $OwnerSignUpStateCopyWith<$Res> {
+  factory $OwnerSignUpStateCopyWith(
+          OwnerSignUpState value, $Res Function(OwnerSignUpState) then) =
+      _$OwnerSignUpStateCopyWithImpl<$Res, OwnerSignUpState>;
+  @useResult
+  $Res call(
+      {String storeName,
+      String email,
+      String password,
+      String confirmPassword,
+      String zipCode,
+      String state,
+      String city,
+      String address,
+      String? building,
+      String? emailError,
+      String? passwordError,
+      String? confirmPasswordError,
+      String? verificationErrorMessage,
+      bool isPasswordVisible,
+      bool isConfirmPasswordVisible,
+      bool isLoading,
+      String? verificationCode,
+      Owner? owner,
+      bool signUpSuccess,
+      String? signUpError,
+      bool verificationSuccess,
+      bool resendCodeSuccess,
+      String? resendCodeError});
+
+  $OwnerCopyWith<$Res>? get owner;
+}
+
+/// @nodoc
+class _$OwnerSignUpStateCopyWithImpl<$Res, $Val extends OwnerSignUpState>
+    implements $OwnerSignUpStateCopyWith<$Res> {
+  _$OwnerSignUpStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of OwnerSignUpState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeName = null,
+    Object? email = null,
+    Object? password = null,
+    Object? confirmPassword = null,
+    Object? zipCode = null,
+    Object? state = null,
+    Object? city = null,
+    Object? address = null,
+    Object? building = freezed,
+    Object? emailError = freezed,
+    Object? passwordError = freezed,
+    Object? confirmPasswordError = freezed,
+    Object? verificationErrorMessage = freezed,
+    Object? isPasswordVisible = null,
+    Object? isConfirmPasswordVisible = null,
+    Object? isLoading = null,
+    Object? verificationCode = freezed,
+    Object? owner = freezed,
+    Object? signUpSuccess = null,
+    Object? signUpError = freezed,
+    Object? verificationSuccess = null,
+    Object? resendCodeSuccess = null,
+    Object? resendCodeError = freezed,
+  }) {
+    return _then(_value.copyWith(
+      storeName: null == storeName
+          ? _value.storeName
+          : storeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _value.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+      confirmPassword: null == confirmPassword
+          ? _value.confirmPassword
+          : confirmPassword // ignore: cast_nullable_to_non_nullable
+              as String,
+      zipCode: null == zipCode
+          ? _value.zipCode
+          : zipCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      state: null == state
+          ? _value.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as String,
+      city: null == city
+          ? _value.city
+          : city // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      building: freezed == building
+          ? _value.building
+          : building // ignore: cast_nullable_to_non_nullable
+              as String?,
+      emailError: freezed == emailError
+          ? _value.emailError
+          : emailError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      passwordError: freezed == passwordError
+          ? _value.passwordError
+          : passwordError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      confirmPasswordError: freezed == confirmPasswordError
+          ? _value.confirmPasswordError
+          : confirmPasswordError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      verificationErrorMessage: freezed == verificationErrorMessage
+          ? _value.verificationErrorMessage
+          : verificationErrorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isPasswordVisible: null == isPasswordVisible
+          ? _value.isPasswordVisible
+          : isPasswordVisible // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isConfirmPasswordVisible: null == isConfirmPasswordVisible
+          ? _value.isConfirmPasswordVisible
+          : isConfirmPasswordVisible // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isLoading: null == isLoading
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      verificationCode: freezed == verificationCode
+          ? _value.verificationCode
+          : verificationCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      owner: freezed == owner
+          ? _value.owner
+          : owner // ignore: cast_nullable_to_non_nullable
+              as Owner?,
+      signUpSuccess: null == signUpSuccess
+          ? _value.signUpSuccess
+          : signUpSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      signUpError: freezed == signUpError
+          ? _value.signUpError
+          : signUpError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      verificationSuccess: null == verificationSuccess
+          ? _value.verificationSuccess
+          : verificationSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      resendCodeSuccess: null == resendCodeSuccess
+          ? _value.resendCodeSuccess
+          : resendCodeSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      resendCodeError: freezed == resendCodeError
+          ? _value.resendCodeError
+          : resendCodeError // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  /// Create a copy of OwnerSignUpState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $OwnerCopyWith<$Res>? get owner {
+    if (_value.owner == null) {
+      return null;
+    }
+
+    return $OwnerCopyWith<$Res>(_value.owner!, (value) {
+      return _then(_value.copyWith(owner: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$OwnerSignUpStateImplCopyWith<$Res>
+    implements $OwnerSignUpStateCopyWith<$Res> {
+  factory _$$OwnerSignUpStateImplCopyWith(_$OwnerSignUpStateImpl value,
+          $Res Function(_$OwnerSignUpStateImpl) then) =
+      __$$OwnerSignUpStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String storeName,
+      String email,
+      String password,
+      String confirmPassword,
+      String zipCode,
+      String state,
+      String city,
+      String address,
+      String? building,
+      String? emailError,
+      String? passwordError,
+      String? confirmPasswordError,
+      String? verificationErrorMessage,
+      bool isPasswordVisible,
+      bool isConfirmPasswordVisible,
+      bool isLoading,
+      String? verificationCode,
+      Owner? owner,
+      bool signUpSuccess,
+      String? signUpError,
+      bool verificationSuccess,
+      bool resendCodeSuccess,
+      String? resendCodeError});
+
+  @override
+  $OwnerCopyWith<$Res>? get owner;
+}
+
+/// @nodoc
+class __$$OwnerSignUpStateImplCopyWithImpl<$Res>
+    extends _$OwnerSignUpStateCopyWithImpl<$Res, _$OwnerSignUpStateImpl>
+    implements _$$OwnerSignUpStateImplCopyWith<$Res> {
+  __$$OwnerSignUpStateImplCopyWithImpl(_$OwnerSignUpStateImpl _value,
+      $Res Function(_$OwnerSignUpStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of OwnerSignUpState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeName = null,
+    Object? email = null,
+    Object? password = null,
+    Object? confirmPassword = null,
+    Object? zipCode = null,
+    Object? state = null,
+    Object? city = null,
+    Object? address = null,
+    Object? building = freezed,
+    Object? emailError = freezed,
+    Object? passwordError = freezed,
+    Object? confirmPasswordError = freezed,
+    Object? verificationErrorMessage = freezed,
+    Object? isPasswordVisible = null,
+    Object? isConfirmPasswordVisible = null,
+    Object? isLoading = null,
+    Object? verificationCode = freezed,
+    Object? owner = freezed,
+    Object? signUpSuccess = null,
+    Object? signUpError = freezed,
+    Object? verificationSuccess = null,
+    Object? resendCodeSuccess = null,
+    Object? resendCodeError = freezed,
+  }) {
+    return _then(_$OwnerSignUpStateImpl(
+      storeName: null == storeName
+          ? _value.storeName
+          : storeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      email: null == email
+          ? _value.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _value.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+      confirmPassword: null == confirmPassword
+          ? _value.confirmPassword
+          : confirmPassword // ignore: cast_nullable_to_non_nullable
+              as String,
+      zipCode: null == zipCode
+          ? _value.zipCode
+          : zipCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      state: null == state
+          ? _value.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as String,
+      city: null == city
+          ? _value.city
+          : city // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      building: freezed == building
+          ? _value.building
+          : building // ignore: cast_nullable_to_non_nullable
+              as String?,
+      emailError: freezed == emailError
+          ? _value.emailError
+          : emailError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      passwordError: freezed == passwordError
+          ? _value.passwordError
+          : passwordError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      confirmPasswordError: freezed == confirmPasswordError
+          ? _value.confirmPasswordError
+          : confirmPasswordError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      verificationErrorMessage: freezed == verificationErrorMessage
+          ? _value.verificationErrorMessage
+          : verificationErrorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isPasswordVisible: null == isPasswordVisible
+          ? _value.isPasswordVisible
+          : isPasswordVisible // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isConfirmPasswordVisible: null == isConfirmPasswordVisible
+          ? _value.isConfirmPasswordVisible
+          : isConfirmPasswordVisible // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isLoading: null == isLoading
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      verificationCode: freezed == verificationCode
+          ? _value.verificationCode
+          : verificationCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      owner: freezed == owner
+          ? _value.owner
+          : owner // ignore: cast_nullable_to_non_nullable
+              as Owner?,
+      signUpSuccess: null == signUpSuccess
+          ? _value.signUpSuccess
+          : signUpSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      signUpError: freezed == signUpError
+          ? _value.signUpError
+          : signUpError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      verificationSuccess: null == verificationSuccess
+          ? _value.verificationSuccess
+          : verificationSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      resendCodeSuccess: null == resendCodeSuccess
+          ? _value.resendCodeSuccess
+          : resendCodeSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      resendCodeError: freezed == resendCodeError
+          ? _value.resendCodeError
+          : resendCodeError // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$OwnerSignUpStateImpl implements _OwnerSignUpState {
+  const _$OwnerSignUpStateImpl(
+      {this.storeName = '',
+      this.email = '',
+      this.password = '',
+      this.confirmPassword = '',
+      this.zipCode = '',
+      this.state = '',
+      this.city = '',
+      this.address = '',
+      this.building,
+      this.emailError,
+      this.passwordError,
+      this.confirmPasswordError,
+      this.verificationErrorMessage,
+      this.isPasswordVisible = false,
+      this.isConfirmPasswordVisible = false,
+      this.isLoading = false,
+      this.verificationCode,
+      this.owner,
+      this.signUpSuccess = false,
+      this.signUpError,
+      this.verificationSuccess = false,
+      this.resendCodeSuccess = false,
+      this.resendCodeError});
+
+  factory _$OwnerSignUpStateImpl.fromJson(Map<String, dynamic> json) =>
+      _$$OwnerSignUpStateImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final String storeName;
+  @override
+  @JsonKey()
+  final String email;
+  @override
+  @JsonKey()
+  final String password;
+  @override
+  @JsonKey()
+  final String confirmPassword;
+  @override
+  @JsonKey()
+  final String zipCode;
+  @override
+  @JsonKey()
+  final String state;
+  @override
+  @JsonKey()
+  final String city;
+  @override
+  @JsonKey()
+  final String address;
+  @override
+  final String? building;
+  @override
+  final String? emailError;
+  @override
+  final String? passwordError;
+  @override
+  final String? confirmPasswordError;
+  @override
+  final String? verificationErrorMessage;
+  @override
+  @JsonKey()
+  final bool isPasswordVisible;
+  @override
+  @JsonKey()
+  final bool isConfirmPasswordVisible;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? verificationCode;
+  @override
+  final Owner? owner;
+  @override
+  @JsonKey()
+  final bool signUpSuccess;
+  @override
+  final String? signUpError;
+  @override
+  @JsonKey()
+  final bool verificationSuccess;
+  @override
+  @JsonKey()
+  final bool resendCodeSuccess;
+  @override
+  final String? resendCodeError;
+
+  @override
+  String toString() {
+    return 'OwnerSignUpState(storeName: $storeName, email: $email, password: $password, confirmPassword: $confirmPassword, zipCode: $zipCode, state: $state, city: $city, address: $address, building: $building, emailError: $emailError, passwordError: $passwordError, confirmPasswordError: $confirmPasswordError, verificationErrorMessage: $verificationErrorMessage, isPasswordVisible: $isPasswordVisible, isConfirmPasswordVisible: $isConfirmPasswordVisible, isLoading: $isLoading, verificationCode: $verificationCode, owner: $owner, signUpSuccess: $signUpSuccess, signUpError: $signUpError, verificationSuccess: $verificationSuccess, resendCodeSuccess: $resendCodeSuccess, resendCodeError: $resendCodeError)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OwnerSignUpStateImpl &&
+            (identical(other.storeName, storeName) ||
+                other.storeName == storeName) &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.password, password) ||
+                other.password == password) &&
+            (identical(other.confirmPassword, confirmPassword) ||
+                other.confirmPassword == confirmPassword) &&
+            (identical(other.zipCode, zipCode) || other.zipCode == zipCode) &&
+            (identical(other.state, state) || other.state == state) &&
+            (identical(other.city, city) || other.city == city) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.building, building) ||
+                other.building == building) &&
+            (identical(other.emailError, emailError) ||
+                other.emailError == emailError) &&
+            (identical(other.passwordError, passwordError) ||
+                other.passwordError == passwordError) &&
+            (identical(other.confirmPasswordError, confirmPasswordError) ||
+                other.confirmPasswordError == confirmPasswordError) &&
+            (identical(
+                    other.verificationErrorMessage, verificationErrorMessage) ||
+                other.verificationErrorMessage == verificationErrorMessage) &&
+            (identical(other.isPasswordVisible, isPasswordVisible) ||
+                other.isPasswordVisible == isPasswordVisible) &&
+            (identical(
+                    other.isConfirmPasswordVisible, isConfirmPasswordVisible) ||
+                other.isConfirmPasswordVisible == isConfirmPasswordVisible) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.verificationCode, verificationCode) ||
+                other.verificationCode == verificationCode) &&
+            (identical(other.owner, owner) || other.owner == owner) &&
+            (identical(other.signUpSuccess, signUpSuccess) ||
+                other.signUpSuccess == signUpSuccess) &&
+            (identical(other.signUpError, signUpError) ||
+                other.signUpError == signUpError) &&
+            (identical(other.verificationSuccess, verificationSuccess) ||
+                other.verificationSuccess == verificationSuccess) &&
+            (identical(other.resendCodeSuccess, resendCodeSuccess) ||
+                other.resendCodeSuccess == resendCodeSuccess) &&
+            (identical(other.resendCodeError, resendCodeError) ||
+                other.resendCodeError == resendCodeError));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        storeName,
+        email,
+        password,
+        confirmPassword,
+        zipCode,
+        state,
+        city,
+        address,
+        building,
+        emailError,
+        passwordError,
+        confirmPasswordError,
+        verificationErrorMessage,
+        isPasswordVisible,
+        isConfirmPasswordVisible,
+        isLoading,
+        verificationCode,
+        owner,
+        signUpSuccess,
+        signUpError,
+        verificationSuccess,
+        resendCodeSuccess,
+        resendCodeError
+      ]);
+
+  /// Create a copy of OwnerSignUpState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OwnerSignUpStateImplCopyWith<_$OwnerSignUpStateImpl> get copyWith =>
+      __$$OwnerSignUpStateImplCopyWithImpl<_$OwnerSignUpStateImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$OwnerSignUpStateImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _OwnerSignUpState implements OwnerSignUpState {
+  const factory _OwnerSignUpState(
+      {final String storeName,
+      final String email,
+      final String password,
+      final String confirmPassword,
+      final String zipCode,
+      final String state,
+      final String city,
+      final String address,
+      final String? building,
+      final String? emailError,
+      final String? passwordError,
+      final String? confirmPasswordError,
+      final String? verificationErrorMessage,
+      final bool isPasswordVisible,
+      final bool isConfirmPasswordVisible,
+      final bool isLoading,
+      final String? verificationCode,
+      final Owner? owner,
+      final bool signUpSuccess,
+      final String? signUpError,
+      final bool verificationSuccess,
+      final bool resendCodeSuccess,
+      final String? resendCodeError}) = _$OwnerSignUpStateImpl;
+
+  factory _OwnerSignUpState.fromJson(Map<String, dynamic> json) =
+      _$OwnerSignUpStateImpl.fromJson;
+
+  @override
+  String get storeName;
+  @override
+  String get email;
+  @override
+  String get password;
+  @override
+  String get confirmPassword;
+  @override
+  String get zipCode;
+  @override
+  String get state;
+  @override
+  String get city;
+  @override
+  String get address;
+  @override
+  String? get building;
+  @override
+  String? get emailError;
+  @override
+  String? get passwordError;
+  @override
+  String? get confirmPasswordError;
+  @override
+  String? get verificationErrorMessage;
+  @override
+  bool get isPasswordVisible;
+  @override
+  bool get isConfirmPasswordVisible;
+  @override
+  bool get isLoading;
+  @override
+  String? get verificationCode;
+  @override
+  Owner? get owner;
+  @override
+  bool get signUpSuccess;
+  @override
+  String? get signUpError;
+  @override
+  bool get verificationSuccess;
+  @override
+  bool get resendCodeSuccess;
+  @override
+  String? get resendCodeError;
+
+  /// Create a copy of OwnerSignUpState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$OwnerSignUpStateImplCopyWith<_$OwnerSignUpStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/owner_signup_state_model.g.dart
+++ b/lib/model/owner_signup_state_model.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'owner_signup_state_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$OwnerSignUpStateImpl _$$OwnerSignUpStateImplFromJson(
+        Map<String, dynamic> json) =>
+    _$OwnerSignUpStateImpl(
+      storeName: json['storeName'] as String? ?? '',
+      email: json['email'] as String? ?? '',
+      password: json['password'] as String? ?? '',
+      confirmPassword: json['confirmPassword'] as String? ?? '',
+      zipCode: json['zipCode'] as String? ?? '',
+      state: json['state'] as String? ?? '',
+      city: json['city'] as String? ?? '',
+      address: json['address'] as String? ?? '',
+      building: json['building'] as String?,
+      emailError: json['emailError'] as String?,
+      passwordError: json['passwordError'] as String?,
+      confirmPasswordError: json['confirmPasswordError'] as String?,
+      verificationErrorMessage: json['verificationErrorMessage'] as String?,
+      isPasswordVisible: json['isPasswordVisible'] as bool? ?? false,
+      isConfirmPasswordVisible:
+          json['isConfirmPasswordVisible'] as bool? ?? false,
+      isLoading: json['isLoading'] as bool? ?? false,
+      verificationCode: json['verificationCode'] as String?,
+      owner: json['owner'] == null
+          ? null
+          : Owner.fromJson(json['owner'] as Map<String, dynamic>),
+      signUpSuccess: json['signUpSuccess'] as bool? ?? false,
+      signUpError: json['signUpError'] as String?,
+      verificationSuccess: json['verificationSuccess'] as bool? ?? false,
+      resendCodeSuccess: json['resendCodeSuccess'] as bool? ?? false,
+      resendCodeError: json['resendCodeError'] as String?,
+    );
+
+Map<String, dynamic> _$$OwnerSignUpStateImplToJson(
+        _$OwnerSignUpStateImpl instance) =>
+    <String, dynamic>{
+      'storeName': instance.storeName,
+      'email': instance.email,
+      'password': instance.password,
+      'confirmPassword': instance.confirmPassword,
+      'zipCode': instance.zipCode,
+      'state': instance.state,
+      'city': instance.city,
+      'address': instance.address,
+      'building': instance.building,
+      'emailError': instance.emailError,
+      'passwordError': instance.passwordError,
+      'confirmPasswordError': instance.confirmPasswordError,
+      'verificationErrorMessage': instance.verificationErrorMessage,
+      'isPasswordVisible': instance.isPasswordVisible,
+      'isConfirmPasswordVisible': instance.isConfirmPasswordVisible,
+      'isLoading': instance.isLoading,
+      'verificationCode': instance.verificationCode,
+      'owner': instance.owner,
+      'signUpSuccess': instance.signUpSuccess,
+      'signUpError': instance.signUpError,
+      'verificationSuccess': instance.verificationSuccess,
+      'resendCodeSuccess': instance.resendCodeSuccess,
+      'resendCodeError': instance.resendCodeError,
+    };

--- a/lib/model/photo_upload_model.dart
+++ b/lib/model/photo_upload_model.dart
@@ -1,37 +1,19 @@
-class PhotoUpload {
-  final String pubId;
-  final String ownerId; // 소유자 ID (이메일 등)
-  final String? logoUrl; // 가게 로고 URL
-  final List<String?> photoUrls; // 가게 이미지 URL 리스트
-  final String message; // 가게 메시지
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-  PhotoUpload({
-    required this.pubId,
-    required this.ownerId,
-    required this.logoUrl,
-    required this.photoUrls,
-    required this.message,
-  });
+part 'photo_upload_model.freezed.dart';
+part 'photo_upload_model.g.dart';
 
-  /// Firestore에 저장할 때 사용할 Map 형태로 변환
-  Map<String, dynamic> toMap() {
-    return {
-      'pubId': pubId,
-      'ownerId': ownerId,
-      'logoUrl': logoUrl,
-      'photoUrls': photoUrls,
-      'message': message,
-    };
-  }
+@freezed
+class PhotoUpload with _$PhotoUpload {
+  const factory PhotoUpload({
+    @Default('') String pubId,
+    required String ownerId,
+    String? logoUrl,
+    required List<String?> photoUrls,
+    required String message,
+  }) = _PhotoUpload;
 
   /// Firestore에서 데이터를 가져올 때 사용할 팩토리 생성자
-  factory PhotoUpload.fromMap(Map<String, dynamic> map) {
-    return PhotoUpload(
-      pubId: map['pubId'] ?? '',
-      ownerId: map['ownerId'],
-      logoUrl: map['logoUrl'],
-      photoUrls: List<String?>.from(map['photoUrls']),
-      message: map['message'],
-    );
-  }
+  factory PhotoUpload.fromJson(Map<String, dynamic> json) =>
+      _$PhotoUploadFromJson(json);
 }

--- a/lib/model/photo_upload_model.freezed.dart
+++ b/lib/model/photo_upload_model.freezed.dart
@@ -1,0 +1,258 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'photo_upload_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PhotoUpload _$PhotoUploadFromJson(Map<String, dynamic> json) {
+  return _PhotoUpload.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PhotoUpload {
+  String get pubId => throw _privateConstructorUsedError;
+  String get ownerId => throw _privateConstructorUsedError;
+  String? get logoUrl => throw _privateConstructorUsedError;
+  List<String?> get photoUrls => throw _privateConstructorUsedError;
+  String get message => throw _privateConstructorUsedError;
+
+  /// Serializes this PhotoUpload to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of PhotoUpload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PhotoUploadCopyWith<PhotoUpload> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PhotoUploadCopyWith<$Res> {
+  factory $PhotoUploadCopyWith(
+          PhotoUpload value, $Res Function(PhotoUpload) then) =
+      _$PhotoUploadCopyWithImpl<$Res, PhotoUpload>;
+  @useResult
+  $Res call(
+      {String pubId,
+      String ownerId,
+      String? logoUrl,
+      List<String?> photoUrls,
+      String message});
+}
+
+/// @nodoc
+class _$PhotoUploadCopyWithImpl<$Res, $Val extends PhotoUpload>
+    implements $PhotoUploadCopyWith<$Res> {
+  _$PhotoUploadCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PhotoUpload
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pubId = null,
+    Object? ownerId = null,
+    Object? logoUrl = freezed,
+    Object? photoUrls = null,
+    Object? message = null,
+  }) {
+    return _then(_value.copyWith(
+      pubId: null == pubId
+          ? _value.pubId
+          : pubId // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownerId: null == ownerId
+          ? _value.ownerId
+          : ownerId // ignore: cast_nullable_to_non_nullable
+              as String,
+      logoUrl: freezed == logoUrl
+          ? _value.logoUrl
+          : logoUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      photoUrls: null == photoUrls
+          ? _value.photoUrls
+          : photoUrls // ignore: cast_nullable_to_non_nullable
+              as List<String?>,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PhotoUploadImplCopyWith<$Res>
+    implements $PhotoUploadCopyWith<$Res> {
+  factory _$$PhotoUploadImplCopyWith(
+          _$PhotoUploadImpl value, $Res Function(_$PhotoUploadImpl) then) =
+      __$$PhotoUploadImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String pubId,
+      String ownerId,
+      String? logoUrl,
+      List<String?> photoUrls,
+      String message});
+}
+
+/// @nodoc
+class __$$PhotoUploadImplCopyWithImpl<$Res>
+    extends _$PhotoUploadCopyWithImpl<$Res, _$PhotoUploadImpl>
+    implements _$$PhotoUploadImplCopyWith<$Res> {
+  __$$PhotoUploadImplCopyWithImpl(
+      _$PhotoUploadImpl _value, $Res Function(_$PhotoUploadImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of PhotoUpload
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pubId = null,
+    Object? ownerId = null,
+    Object? logoUrl = freezed,
+    Object? photoUrls = null,
+    Object? message = null,
+  }) {
+    return _then(_$PhotoUploadImpl(
+      pubId: null == pubId
+          ? _value.pubId
+          : pubId // ignore: cast_nullable_to_non_nullable
+              as String,
+      ownerId: null == ownerId
+          ? _value.ownerId
+          : ownerId // ignore: cast_nullable_to_non_nullable
+              as String,
+      logoUrl: freezed == logoUrl
+          ? _value.logoUrl
+          : logoUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      photoUrls: null == photoUrls
+          ? _value._photoUrls
+          : photoUrls // ignore: cast_nullable_to_non_nullable
+              as List<String?>,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PhotoUploadImpl implements _PhotoUpload {
+  const _$PhotoUploadImpl(
+      {this.pubId = '',
+      required this.ownerId,
+      this.logoUrl,
+      required final List<String?> photoUrls,
+      required this.message})
+      : _photoUrls = photoUrls;
+
+  factory _$PhotoUploadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PhotoUploadImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final String pubId;
+  @override
+  final String ownerId;
+  @override
+  final String? logoUrl;
+  final List<String?> _photoUrls;
+  @override
+  List<String?> get photoUrls {
+    if (_photoUrls is EqualUnmodifiableListView) return _photoUrls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_photoUrls);
+  }
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'PhotoUpload(pubId: $pubId, ownerId: $ownerId, logoUrl: $logoUrl, photoUrls: $photoUrls, message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PhotoUploadImpl &&
+            (identical(other.pubId, pubId) || other.pubId == pubId) &&
+            (identical(other.ownerId, ownerId) || other.ownerId == ownerId) &&
+            (identical(other.logoUrl, logoUrl) || other.logoUrl == logoUrl) &&
+            const DeepCollectionEquality()
+                .equals(other._photoUrls, _photoUrls) &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, pubId, ownerId, logoUrl,
+      const DeepCollectionEquality().hash(_photoUrls), message);
+
+  /// Create a copy of PhotoUpload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PhotoUploadImplCopyWith<_$PhotoUploadImpl> get copyWith =>
+      __$$PhotoUploadImplCopyWithImpl<_$PhotoUploadImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PhotoUploadImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PhotoUpload implements PhotoUpload {
+  const factory _PhotoUpload(
+      {final String pubId,
+      required final String ownerId,
+      final String? logoUrl,
+      required final List<String?> photoUrls,
+      required final String message}) = _$PhotoUploadImpl;
+
+  factory _PhotoUpload.fromJson(Map<String, dynamic> json) =
+      _$PhotoUploadImpl.fromJson;
+
+  @override
+  String get pubId;
+  @override
+  String get ownerId;
+  @override
+  String? get logoUrl;
+  @override
+  List<String?> get photoUrls;
+  @override
+  String get message;
+
+  /// Create a copy of PhotoUpload
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PhotoUploadImplCopyWith<_$PhotoUploadImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/photo_upload_model.g.dart
+++ b/lib/model/photo_upload_model.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'photo_upload_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PhotoUploadImpl _$$PhotoUploadImplFromJson(Map<String, dynamic> json) =>
+    _$PhotoUploadImpl(
+      pubId: json['pubId'] as String? ?? '',
+      ownerId: json['ownerId'] as String,
+      logoUrl: json['logoUrl'] as String?,
+      photoUrls: (json['photoUrls'] as List<dynamic>)
+          .map((e) => e as String?)
+          .toList(),
+      message: json['message'] as String,
+    );
+
+Map<String, dynamic> _$$PhotoUploadImplToJson(_$PhotoUploadImpl instance) =>
+    <String, dynamic>{
+      'pubId': instance.pubId,
+      'ownerId': instance.ownerId,
+      'logoUrl': instance.logoUrl,
+      'photoUrls': instance.photoUrls,
+      'message': instance.message,
+    };

--- a/lib/model/photo_upload_state_model.dart
+++ b/lib/model/photo_upload_state_model.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:image_picker/image_picker.dart';
+
+part 'photo_upload_state_model.freezed.dart';
+
+@freezed
+class PhotoUploadState with _$PhotoUploadState {
+  const factory PhotoUploadState({
+    required List<XFile?> storeImages,
+    required XFile? storeLogo,
+    required String message,
+    @Default(false) bool isLoading,
+    String? uploadError,
+    String? ownerEmail,
+  }) = _PhotoUploadState;
+}

--- a/lib/model/photo_upload_state_model.freezed.dart
+++ b/lib/model/photo_upload_state_model.freezed.dart
@@ -1,0 +1,268 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'photo_upload_state_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$PhotoUploadState {
+  List<XFile?> get storeImages => throw _privateConstructorUsedError;
+  XFile? get storeLogo => throw _privateConstructorUsedError;
+  String get message => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+  String? get uploadError => throw _privateConstructorUsedError;
+  String? get ownerEmail => throw _privateConstructorUsedError;
+
+  /// Create a copy of PhotoUploadState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PhotoUploadStateCopyWith<PhotoUploadState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PhotoUploadStateCopyWith<$Res> {
+  factory $PhotoUploadStateCopyWith(
+          PhotoUploadState value, $Res Function(PhotoUploadState) then) =
+      _$PhotoUploadStateCopyWithImpl<$Res, PhotoUploadState>;
+  @useResult
+  $Res call(
+      {List<XFile?> storeImages,
+      XFile? storeLogo,
+      String message,
+      bool isLoading,
+      String? uploadError,
+      String? ownerEmail});
+}
+
+/// @nodoc
+class _$PhotoUploadStateCopyWithImpl<$Res, $Val extends PhotoUploadState>
+    implements $PhotoUploadStateCopyWith<$Res> {
+  _$PhotoUploadStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PhotoUploadState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeImages = null,
+    Object? storeLogo = freezed,
+    Object? message = null,
+    Object? isLoading = null,
+    Object? uploadError = freezed,
+    Object? ownerEmail = freezed,
+  }) {
+    return _then(_value.copyWith(
+      storeImages: null == storeImages
+          ? _value.storeImages
+          : storeImages // ignore: cast_nullable_to_non_nullable
+              as List<XFile?>,
+      storeLogo: freezed == storeLogo
+          ? _value.storeLogo
+          : storeLogo // ignore: cast_nullable_to_non_nullable
+              as XFile?,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      isLoading: null == isLoading
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      uploadError: freezed == uploadError
+          ? _value.uploadError
+          : uploadError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      ownerEmail: freezed == ownerEmail
+          ? _value.ownerEmail
+          : ownerEmail // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PhotoUploadStateImplCopyWith<$Res>
+    implements $PhotoUploadStateCopyWith<$Res> {
+  factory _$$PhotoUploadStateImplCopyWith(_$PhotoUploadStateImpl value,
+          $Res Function(_$PhotoUploadStateImpl) then) =
+      __$$PhotoUploadStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {List<XFile?> storeImages,
+      XFile? storeLogo,
+      String message,
+      bool isLoading,
+      String? uploadError,
+      String? ownerEmail});
+}
+
+/// @nodoc
+class __$$PhotoUploadStateImplCopyWithImpl<$Res>
+    extends _$PhotoUploadStateCopyWithImpl<$Res, _$PhotoUploadStateImpl>
+    implements _$$PhotoUploadStateImplCopyWith<$Res> {
+  __$$PhotoUploadStateImplCopyWithImpl(_$PhotoUploadStateImpl _value,
+      $Res Function(_$PhotoUploadStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of PhotoUploadState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeImages = null,
+    Object? storeLogo = freezed,
+    Object? message = null,
+    Object? isLoading = null,
+    Object? uploadError = freezed,
+    Object? ownerEmail = freezed,
+  }) {
+    return _then(_$PhotoUploadStateImpl(
+      storeImages: null == storeImages
+          ? _value._storeImages
+          : storeImages // ignore: cast_nullable_to_non_nullable
+              as List<XFile?>,
+      storeLogo: freezed == storeLogo
+          ? _value.storeLogo
+          : storeLogo // ignore: cast_nullable_to_non_nullable
+              as XFile?,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      isLoading: null == isLoading
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      uploadError: freezed == uploadError
+          ? _value.uploadError
+          : uploadError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      ownerEmail: freezed == ownerEmail
+          ? _value.ownerEmail
+          : ownerEmail // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PhotoUploadStateImpl implements _PhotoUploadState {
+  const _$PhotoUploadStateImpl(
+      {required final List<XFile?> storeImages,
+      required this.storeLogo,
+      required this.message,
+      this.isLoading = false,
+      this.uploadError,
+      this.ownerEmail})
+      : _storeImages = storeImages;
+
+  final List<XFile?> _storeImages;
+  @override
+  List<XFile?> get storeImages {
+    if (_storeImages is EqualUnmodifiableListView) return _storeImages;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_storeImages);
+  }
+
+  @override
+  final XFile? storeLogo;
+  @override
+  final String message;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? uploadError;
+  @override
+  final String? ownerEmail;
+
+  @override
+  String toString() {
+    return 'PhotoUploadState(storeImages: $storeImages, storeLogo: $storeLogo, message: $message, isLoading: $isLoading, uploadError: $uploadError, ownerEmail: $ownerEmail)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PhotoUploadStateImpl &&
+            const DeepCollectionEquality()
+                .equals(other._storeImages, _storeImages) &&
+            (identical(other.storeLogo, storeLogo) ||
+                other.storeLogo == storeLogo) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.uploadError, uploadError) ||
+                other.uploadError == uploadError) &&
+            (identical(other.ownerEmail, ownerEmail) ||
+                other.ownerEmail == ownerEmail));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_storeImages),
+      storeLogo,
+      message,
+      isLoading,
+      uploadError,
+      ownerEmail);
+
+  /// Create a copy of PhotoUploadState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PhotoUploadStateImplCopyWith<_$PhotoUploadStateImpl> get copyWith =>
+      __$$PhotoUploadStateImplCopyWithImpl<_$PhotoUploadStateImpl>(
+          this, _$identity);
+}
+
+abstract class _PhotoUploadState implements PhotoUploadState {
+  const factory _PhotoUploadState(
+      {required final List<XFile?> storeImages,
+      required final XFile? storeLogo,
+      required final String message,
+      final bool isLoading,
+      final String? uploadError,
+      final String? ownerEmail}) = _$PhotoUploadStateImpl;
+
+  @override
+  List<XFile?> get storeImages;
+  @override
+  XFile? get storeLogo;
+  @override
+  String get message;
+  @override
+  bool get isLoading;
+  @override
+  String? get uploadError;
+  @override
+  String? get ownerEmail;
+
+  /// Create a copy of PhotoUploadState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PhotoUploadStateImplCopyWith<_$PhotoUploadStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/services/preferences_manager.dart
+++ b/lib/services/preferences_manager.dart
@@ -46,4 +46,14 @@ class PreferencesManager {
   Future<void> logout() async {
     await _preferences?.clear(); // 모든 SharedPreferences 데이터 삭제
   }
+
+  // 알림 상태 가져오기 
+  bool getNotificationStatus() {
+    return _preferences?.getBool('notificationStatus') ?? true; // 기본값은 true
+  }
+
+  // 알림 상태 저장
+  Future<void> setNotificationStatus(bool value) async {
+    await _preferences?.setBool('notificationStatus', value);
+  }
 }

--- a/lib/view/sign-up/owner_email_auth_screen.dart
+++ b/lib/view/sign-up/owner_email_auth_screen.dart
@@ -1,40 +1,69 @@
+// owner_email_auth_screen.dart
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../viewModel/owner_sign_up_view_model.dart'; // SignUpViewModel 가져오기
-import '../../model/owner_model.dart'; // User 모델 가져오기
-import 'dart:io'; // File 사용을 위한 패키지
+import '../../viewModel/owner_sign_up_view_model.dart';
 
-// 이메일 인증 화면 클래스 (ConsumerWidget을 사용하여 Riverpod 상태를 감시)
-class OwnerEmailAuthScreen extends ConsumerWidget {
-  final Owner owner; // 이메일 인증 대상인 사용자
-  final List<File?> images; // 가게 이미지 파일 리스트
-  final File? logo; // 가게 로고 파일
-  final String message; // 가게 메시지
+class OwnerEmailAuthScreen extends ConsumerStatefulWidget {
+  @override
+  _OwnerEmailAuthScreenState createState() => _OwnerEmailAuthScreenState();
+}
 
-  // 생성자에서 필수적으로 User 객체, 이미지들, 로고, 메시지를 받아옴
-  OwnerEmailAuthScreen({
-    required this.owner,
-    required this.images,
-    required this.logo,
-    required this.message,
-  });
+class _OwnerEmailAuthScreenState extends ConsumerState<OwnerEmailAuthScreen> {
+  final TextEditingController _codeController = TextEditingController();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  void dispose() {
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final signUpState = ref.watch(ownerSignUpViewModelProvider);
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
+    // 인증 성공 시 초기 화면으로 이동
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (signUpState.verificationSuccess) {
+        Navigator.popUntil(context, (route) => route.isFirst);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('アカウント登録が完了しました。')),
+        );
+        signUpViewModel.resetVerificationSuccess();
+      }
+
+      if (signUpState.verificationErrorMessage != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(signUpState.verificationErrorMessage!)),
+        );
+        signUpViewModel.resetVerificationError();
+      }
+
+      if (signUpState.resendCodeSuccess) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('新しいコードが送信されました。')),
+        );
+        signUpViewModel.resetResendCodeSuccess();
+      }
+
+      if (signUpState.resendCodeError != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(signUpState.resendCodeError!)),
+        );
+        signUpViewModel.resetResendCodeError();
+      }
+    });
+
     // 화면 크기 정보 가져오기
     final screenSize = MediaQuery.of(context).size;
     final screenWidth = screenSize.width;
     final screenHeight = screenSize.height;
 
-    // SignUpState 및 SignUpViewModel 상태를 감시
-    final signUpState = ref.watch(ownersignUpViewModelProvider); 
-    final signUpViewModel = ref.read(ownersignUpViewModelProvider.notifier);
+    final owner = signUpState.owner;
 
-    return PopScope<Object?>(
-      canPop: false, // 뒤로 가기 제스처 및 버튼을 막음
-      onPopInvokedWithResult: (bool didPop, Object? result) {
-        // 뒤로 가기 동작을 하지 않도록 막음 (아무 동작도 하지 않음)
-      },
+    return WillPopScope(
+      onWillPop: () async => false, // 뒤로 가기 방지
       child: Scaffold(
         appBar: AppBar(
           leading: IconButton(
@@ -44,95 +73,88 @@ class OwnerEmailAuthScreen extends ConsumerWidget {
           backgroundColor: Colors.transparent, // AppBar의 배경색 투명
           elevation: 0, // 그림자 제거
         ),
-        // 본문 내용
         body: Padding(
           padding: EdgeInsets.all(screenWidth * 0.05), // 화면 여백을 상대적으로 설정
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start, // 왼쪽 정렬
             children: [
-              // 중앙에 위치한 타이틀 텍스트
               Center(
                 child: Text(
-                  'アカウント認証', // 'アカウント認証' = 계정 인증
+                  'アカウント認証', // 타이틀
                   style: TextStyle(
-                    fontSize: screenWidth * 0.07, // 폰트 크기를 상대적으로 설정
+                    fontSize: screenWidth * 0.07,
                     fontWeight: FontWeight.bold,
                   ),
                 ),
               ),
-              SizedBox(height: screenHeight * 0.02), // 간격을 상대적으로 설정
-              // 사용자 이메일 정보와 안내 메시지
+              SizedBox(height: screenHeight * 0.02), // 간격
+
               Center(
                 child: Text(
-                  '${owner.email}に認証コードを送りました。\n認証コードを入力してください。', 
-                  // '認証コードを送りました。' = 인증 코드를 보냈습니다.
-                  textAlign: TextAlign.center, // 텍스트 가운데 정렬
-                  style: TextStyle(fontSize: screenWidth * 0.038, color: Colors.black), // 텍스트 크기를 상대적으로 설정
+                  '${owner?.email ?? ''}に認証コードを送りました。\n認証コードを入力してください。',
+                  textAlign: TextAlign.center,
+                  style:
+                      TextStyle(fontSize: screenWidth * 0.038, color: Colors.black),
                 ),
               ),
-              SizedBox(height: screenHeight * 0.04), // 간격을 상대적으로 설정
-              // 인증 코드 입력 필드 라벨
+              SizedBox(height: screenHeight * 0.04), // 간격
+
               Text(
-                '認証コード', // '認証コード' = 인증 코드
-                style: TextStyle(fontSize: screenWidth * 0.045), // 폰트 크기를 상대적으로 설정
+                '認証コード',
+                style: TextStyle(fontSize: screenWidth * 0.045),
               ),
-              SizedBox(height: screenHeight * 0.01), // 간격을 상대적으로 설정
-              // 인증 코드 입력 필드
+              SizedBox(height: screenHeight * 0.01), // 간격
+
               TextField(
-                controller: signUpState.codeController, // 인증 코드 입력을 위한 컨트롤러
+                controller: _codeController,
                 decoration: InputDecoration(
-                  hintText: '4桁コードを入力', // '4桁コードを入力' = 4자리 코드를 입력
+                  hintText: '4桁コードを入力',
                   border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(screenWidth * 0.03), // 필드 테두리를 상대적으로 설정
+                    borderRadius: BorderRadius.circular(screenWidth * 0.03),
                     borderSide: BorderSide(color: Colors.grey),
                   ),
                 ),
-                keyboardType: TextInputType.number, // 숫자 입력만 가능하도록 설정
-                maxLength: 4, // 최대 입력 길이 4자리로 설정
+                keyboardType: TextInputType.number,
+                maxLength: 4,
               ),
-              Spacer(), // 화면 남은 공간 채우기 (필드와 버튼 사이 간격 유지)
-              // 코드 재전송 버튼
+              Spacer(),
+
               Center(
                 child: TextButton(
                   onPressed: () {
-                    signUpViewModel.resendVerificationCode(); // 코드 재전송 함수 호출
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('新しいコードが送信されました。')), 
-                      // '新しいコードが送信されました' = 새로운 코드가 전송되었습니다.
-                    );
+                    signUpViewModel.resendVerificationCode();
                   },
                   child: Text(
-                    'コード再送する', // 'コード再送する' = 코드 재전송
-                    style: TextStyle(color: Colors.blue, fontSize: screenWidth * 0.04), // 텍스트 크기를 상대적으로 설정
+                    'コード再送する',
+                    style:
+                        TextStyle(color: Colors.blue, fontSize: screenWidth * 0.04),
                   ),
                 ),
               ),
-              // 인증 확인 버튼
+
               Center(
                 child: ElevatedButton(
                   onPressed: () async {
-                    // 입력된 코드를 기반으로 인증 처리
-                    await signUpViewModel.verifyCode(
-                      signUpState.codeController.text, 
-                      context, 
-                      owner,
-                      ref,
-                    );
+                    await signUpViewModel.verifyCode(_codeController.text);
                   },
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: Color(0xFF1D2538), // 버튼 배경색 설정
-                    padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.3, vertical: screenHeight * 0.015), // 버튼 크기를 상대적으로 설정
+                    backgroundColor: Color(0xFF1D2538),
+                    padding: EdgeInsets.symmetric(
+                      horizontal: screenWidth * 0.3,
+                      vertical: screenHeight * 0.015,
+                    ),
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(screenWidth * 0.07), // 버튼 모서리를 둥글게 상대적으로 설정
+                      borderRadius: BorderRadius.circular(screenWidth * 0.07),
                     ),
                   ),
                   child: Text(
-                    'アカウント認証', // 'アカウント認証' = 계정 인증
-                    style: TextStyle(fontSize: screenWidth * 0.045, color: Colors.white), // 텍스트 크기를 상대적으로 설정
+                    'アカウント認証',
+                    style: TextStyle(
+                        fontSize: screenWidth * 0.045, color: Colors.white),
                   ),
                 ),
               ),
-              SizedBox(height: screenHeight * 0.05), // 마지막 간격을 상대적으로 설정
+              SizedBox(height: screenHeight * 0.05),
             ],
           ),
         ),

--- a/lib/view/sign-up/owner_email_auth_screen.dart
+++ b/lib/view/sign-up/owner_email_auth_screen.dart
@@ -1,8 +1,7 @@
-// owner_email_auth_screen.dart
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../viewModel/owner_sign_up_view_model.dart';
+import '../../model/owner_signup_state_model.dart';
 
 class OwnerEmailAuthScreen extends ConsumerStatefulWidget {
   @override
@@ -23,139 +22,240 @@ class _OwnerEmailAuthScreenState extends ConsumerState<OwnerEmailAuthScreen> {
     final signUpState = ref.watch(ownerSignUpViewModelProvider);
     final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
 
-    // 인증 성공 시 초기 화면으로 이동
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (signUpState.verificationSuccess) {
-        Navigator.popUntil(context, (route) => route.isFirst);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('アカウント登録が完了しました。')),
-        );
-        signUpViewModel.resetVerificationSuccess();
-      }
-
-      if (signUpState.verificationErrorMessage != null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(signUpState.verificationErrorMessage!)),
-        );
-        signUpViewModel.resetVerificationError();
-      }
-
-      if (signUpState.resendCodeSuccess) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('新しいコードが送信されました。')),
-        );
-        signUpViewModel.resetResendCodeSuccess();
-      }
-
-      if (signUpState.resendCodeError != null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(signUpState.resendCodeError!)),
-        );
-        signUpViewModel.resetResendCodeError();
-      }
+      handleVerificationState(context, signUpState, signUpViewModel);
     });
 
-    // 화면 크기 정보 가져오기
-    final screenSize = MediaQuery.of(context).size;
-    final screenWidth = screenSize.width;
-    final screenHeight = screenSize.height;
-
-    final owner = signUpState.owner;
-
-    return WillPopScope(
-      onWillPop: () async => false, // 뒤로 가기 방지
+    return PopScope<Object?>(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, Object? result) {},
       child: Scaffold(
-        appBar: AppBar(
-          leading: IconButton(
-            icon: Icon(Icons.arrow_back, color: Colors.grey),
-            onPressed: () => Navigator.pop(context), // 뒤로 가기 버튼
-          ),
-          backgroundColor: Colors.transparent, // AppBar의 배경색 투명
-          elevation: 0, // 그림자 제거
+        appBar: CustomAppBar(),
+        body: AuthScreenBody(
+          codeController: _codeController,
+          ownerEmail: signUpState.owner?.email,
+          signUpViewModel: signUpViewModel,
         ),
-        body: Padding(
-          padding: EdgeInsets.all(screenWidth * 0.05), // 화면 여백을 상대적으로 설정
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start, // 왼쪽 정렬
-            children: [
-              Center(
-                child: Text(
-                  'アカウント認証', // 타이틀
-                  style: TextStyle(
-                    fontSize: screenWidth * 0.07,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-              SizedBox(height: screenHeight * 0.02), // 간격
+      ),
+    );
+  }
 
-              Center(
-                child: Text(
-                  '${owner?.email ?? ''}に認証コードを送りました。\n認証コードを入力してください。',
-                  textAlign: TextAlign.center,
-                  style:
-                      TextStyle(fontSize: screenWidth * 0.038, color: Colors.black),
-                ),
-              ),
-              SizedBox(height: screenHeight * 0.04), // 간격
+  void handleVerificationState(
+      BuildContext context, OwnerSignUpState signUpState, OwnerSignUpViewModel signUpViewModel) {
+    if (signUpState.verificationSuccess) {
+      Navigator.popUntil(context, (route) => route.isFirst);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('アカウント登録が完了しました。')),
+      );
+      signUpViewModel.resetVerificationSuccess();
+    }
 
-              Text(
-                '認証コード',
-                style: TextStyle(fontSize: screenWidth * 0.045),
-              ),
-              SizedBox(height: screenHeight * 0.01), // 간격
+    if (signUpState.verificationErrorMessage != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(signUpState.verificationErrorMessage!)),
+      );
+      signUpViewModel.resetVerificationError();
+    }
 
-              TextField(
-                controller: _codeController,
-                decoration: InputDecoration(
-                  hintText: '4桁コードを入力',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(screenWidth * 0.03),
-                    borderSide: BorderSide(color: Colors.grey),
-                  ),
-                ),
-                keyboardType: TextInputType.number,
-                maxLength: 4,
-              ),
-              Spacer(),
+    if (signUpState.resendCodeSuccess) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('新しいコードが送信されました。')),
+      );
+      signUpViewModel.resetResendCodeSuccess();
+    }
 
-              Center(
-                child: TextButton(
-                  onPressed: () {
-                    signUpViewModel.resendVerificationCode();
-                  },
-                  child: Text(
-                    'コード再送する',
-                    style:
-                        TextStyle(color: Colors.blue, fontSize: screenWidth * 0.04),
-                  ),
-                ),
-              ),
+    if (signUpState.resendCodeError != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(signUpState.resendCodeError!)),
+      );
+      signUpViewModel.resetResendCodeError();
+    }
+  }
+}
 
-              Center(
-                child: ElevatedButton(
-                  onPressed: () async {
-                    await signUpViewModel.verifyCode(_codeController.text);
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Color(0xFF1D2538),
-                    padding: EdgeInsets.symmetric(
-                      horizontal: screenWidth * 0.3,
-                      vertical: screenHeight * 0.015,
-                    ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(screenWidth * 0.07),
-                    ),
-                  ),
-                  child: Text(
-                    'アカウント認証',
-                    style: TextStyle(
-                        fontSize: screenWidth * 0.045, color: Colors.white),
-                  ),
-                ),
-              ),
-              SizedBox(height: screenHeight * 0.05),
-            ],
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      leading: IconButton(
+        icon: Icon(Icons.arrow_back, color: Colors.grey),
+        onPressed: () => Navigator.pop(context),
+      ),
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(kToolbarHeight);
+}
+
+class AuthScreenBody extends StatelessWidget {
+  final TextEditingController codeController;
+  final String? ownerEmail;
+  final OwnerSignUpViewModel signUpViewModel;
+
+  AuthScreenBody({
+    required this.codeController,
+    required this.ownerEmail,
+    required this.signUpViewModel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+
+    return Padding(
+      padding: EdgeInsets.all(screenSize.width * 0.05),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TitleSection(screenSize: screenSize),
+          SizedBox(height: screenSize.height * 0.02),
+          DescriptionSection(ownerEmail: ownerEmail, screenSize: screenSize),
+          SizedBox(height: screenSize.height * 0.04),
+          CodeInputField(codeController: codeController, screenSize: screenSize),
+          Spacer(),
+          ResendCodeButton(signUpViewModel: signUpViewModel),
+          SubmitButton(
+            codeController: codeController,
+            signUpViewModel: signUpViewModel,
+            screenSize: screenSize,
+          ),
+          SizedBox(height: screenSize.height * 0.05),
+        ],
+      ),
+    );
+  }
+}
+
+class TitleSection extends StatelessWidget {
+  final Size screenSize;
+
+  TitleSection({required this.screenSize});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        'アカウント認証',
+        style: TextStyle(
+          fontSize: screenSize.width * 0.07,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+class DescriptionSection extends StatelessWidget {
+  final String? ownerEmail;
+  final Size screenSize;
+
+  DescriptionSection({required this.ownerEmail, required this.screenSize});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        '${ownerEmail ?? ''}に認証コードを送りました。\n認証コードを入力してください。',
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: screenSize.width * 0.038,
+          color: Colors.black,
+        ),
+      ),
+    );
+  }
+}
+
+class CodeInputField extends StatelessWidget {
+  final TextEditingController codeController;
+  final Size screenSize;
+
+  CodeInputField({required this.codeController, required this.screenSize});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '認証コード',
+          style: TextStyle(fontSize: screenSize.width * 0.045),
+        ),
+        SizedBox(height: screenSize.height * 0.01),
+        TextField(
+          controller: codeController,
+          decoration: InputDecoration(
+            hintText: '4桁コードを入力',
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(screenSize.width * 0.03),
+              borderSide: BorderSide(color: Colors.grey),
+            ),
+          ),
+          keyboardType: TextInputType.number,
+          maxLength: 4,
+        ),
+      ],
+    );
+  }
+}
+
+class ResendCodeButton extends StatelessWidget {
+  final OwnerSignUpViewModel signUpViewModel;
+
+  ResendCodeButton({required this.signUpViewModel});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: TextButton(
+        onPressed: () {
+          signUpViewModel.resendVerificationCode();
+        },
+        child: Text(
+          'コード再送する',
+          style: TextStyle(color: Colors.blue),
+        ),
+      ),
+    );
+  }
+}
+
+class SubmitButton extends StatelessWidget {
+  final TextEditingController codeController;
+  final OwnerSignUpViewModel signUpViewModel;
+  final Size screenSize;
+
+  SubmitButton({
+    required this.codeController,
+    required this.signUpViewModel,
+    required this.screenSize,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: () async {
+          await signUpViewModel.verifyCode(codeController.text);
+        },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Color(0xFF1D2538),
+          padding: EdgeInsets.symmetric(
+            horizontal: screenSize.width * 0.3,
+            vertical: screenSize.height * 0.015,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(screenSize.width * 0.07),
+          ),
+        ),
+        child: Text(
+          'アカウント認証',
+          style: TextStyle(
+            fontSize: screenSize.width * 0.045,
+            color: Colors.white,
           ),
         ),
       ),

--- a/lib/view/sign-up/owner_sign_up_screen.dart
+++ b/lib/view/sign-up/owner_sign_up_screen.dart
@@ -1,360 +1,430 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../viewModel/owner_sign_up_view_model.dart'; // ViewModel 가져오기
+import '../../viewModel/owner_sign_up_view_model.dart';
+import 'photo_upload_screen.dart'; // photo_upload_screen을 임포트
+import '../../model/owner_signup_state_model.dart';
 
-class OwnerSignUpScreen extends ConsumerWidget {
-  final _formKey = GlobalKey<FormState>();  // 폼의 상태를 관리하기 위한 글로벌 키
+class OwnerSignUpScreen extends ConsumerStatefulWidget {
+  @override
+  _OwnerSignUpScreenState createState() => _OwnerSignUpScreenState();
+}
+
+class _OwnerSignUpScreenState extends ConsumerState<OwnerSignUpScreen> {
+  final _formKey = GlobalKey<FormState>();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final signUpState = ref.watch(ownersignUpViewModelProvider);  // StateNotifierProvider에서 상태 읽기
-    final signUpViewModel = ref.read(ownersignUpViewModelProvider.notifier);  // StateNotifierProvider에서 ViewModel 가져오기
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 상태를 watch하여 변경 시 UI가 리빌드되도록 함
+    final signUpState = ref.watch(ownerSignUpViewModelProvider);
+    // ViewModel을 read하여 상태 변경을 수행
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
+    // 회원가입 성공 시 photo_upload_screen으로 이동
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (signUpState.signUpSuccess) {
+        print('Navigating to PhotoUploadScreen'); // 디버그 로그 추가
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => PhotoUploadScreen(),
+          ),
+        );
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('アカウント作成が完了しました。写真をアップロードしてください。')),
+        );
+        signUpViewModel.resetSignUpSuccess();
+      }
+
+      if (signUpState.signUpError != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(signUpState.signUpError!)),
+        );
+        signUpViewModel.resetSignUpError();
+      }
+    });
 
     // 화면 크기 계산을 위해 MediaQuery 사용
     final screenSize = MediaQuery.of(context).size;
     final screenWidth = screenSize.width;
     final screenHeight = screenSize.height;
 
-    return PopScope<Object?>(
-      canPop: false, // 뒤로 가기 제스처 및 버튼을 막음
-      onPopInvokedWithResult: (bool didPop, Object? result) {
-        // 뒤로 가기 동작을 하지 않도록 막음 (아무 동작도 하지 않음)
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          leading: IconButton(
-            icon: Icon(Icons.arrow_back, color: Colors.grey),
-            onPressed: () => Navigator.pop(context),  // 뒤로 가기 버튼
-          ),
-          backgroundColor: Colors.transparent,  // 앱바 투명 배경
-          elevation: 0,  // 그림자 없애기
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: Colors.grey),
+          onPressed: () => Navigator.pop(context), // 뒤로 가기 버튼
         ),
-        body: SingleChildScrollView(
-          padding: EdgeInsets.all(screenWidth * 0.04),  // 전체 화면 패딩 설정
-          child: Form(
-            key: _formKey,  // 폼 상태 관리
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Center(
-                  child: Text(
-                    '会員登録',  // 타이틀
-                    style: TextStyle(
-                      fontSize: screenWidth * 0.06,  // 상대적인 글자 크기
-                      fontWeight: FontWeight.bold,  // 굵은 글씨체
-                    ),
+        backgroundColor: Colors.transparent, // 앱바 투명 배경
+        elevation: 0, // 그림자 없애기
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(screenWidth * 0.04), // 전체 화면 패딩 설정
+        child: Form(
+          key: _formKey, // 폼 상태 관리
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Text(
+                  '会員登録', // 타이틀
+                  style: TextStyle(
+                    fontSize: screenWidth * 0.06, // 상대적인 글자 크기
+                    fontWeight: FontWeight.bold, // 굵은 글씨체
                   ),
                 ),
-                SizedBox(height: screenHeight * 0.02),  // 여백
-                
-                // '店舗名' 텍스트 필드 빌드
-                _buildTextField(
-                  '店舗名',
-                  '店舗名を入力してください',
-                  signUpState.storeNameController,
-                  screenWidth,
-                  signUpViewModel,
-                ),
-                SizedBox(height: screenHeight * 0.02),  // 여백
-                
-                // 이메일 입력 필드
-                _buildEmailField(
-                  'メールアドレス',
-                  signUpState.emailController,
-                  screenWidth,
-                  signUpState,
-                  signUpViewModel,
-                ),
-                SizedBox(height: screenHeight * 0.02),  // 여백
-                
-                // 비밀번호 입력 필드
-                _buildPasswordField(
-                  'パスワード',
-                  signUpState.passwordController,
-                  screenWidth,
-                  signUpState,
-                  signUpViewModel,
-                ),
-                SizedBox(height: screenHeight * 0.02),  // 여백
-                
-                // 비밀번호 확인 필드
-                _buildConfirmPasswordField(
-                  'パスワード確認',
-                  signUpState.confirmPasswordController,
-                  screenWidth,
-                  signUpState,
-                  signUpViewModel,
-                ),
-                SizedBox(height: screenHeight * 0.02),  // 여백
-                
-                // 우편번호와 도도부현 (都道府県) 입력 필드
-                Row(
-                  children: [
-                    Expanded(
-                      child: _buildTextField(
-                        '郵便番号',
-                        '郵便番号を入力してください',
-                        signUpState.zipCodeController,
-                        screenWidth,
-                        signUpViewModel,
-                      ),
-                    ),
-                    SizedBox(width: screenWidth * 0.02),  // 우편번호와 도도부현 사이의 여백
-                    Expanded(
-                      child: _buildTextField(
-                        '都道府県',
-                        '都道府県を入力してください',
-                        signUpState.stateController,
-                        screenWidth,
-                        signUpViewModel,
-                      ),
-                    ),
-                  ],
-                ),
-                
-                SizedBox(height: screenHeight * 0.02),  // 여백
-                
-                // 시/구/읍/면/동 입력 필드
-                _buildTextField(
-                  '市区町村',
-                  '市区町村を入力してください',
-                  signUpState.cityController,
-                  screenWidth,
-                  signUpViewModel,
-                ),
-                SizedBox(height: screenHeight * 0.02),  // 여백
-                
-                // 상세 주소 입력 필드
-                _buildTextField(
-                  '住所',
-                  '住所を入力してください',
-                  signUpState.addressController,
-                  screenWidth,
-                  signUpViewModel,
-                ),
-                SizedBox(height: screenHeight * 0.02),  // 여백
-                
-                // 건물명/호실번호(선택사항) 입력 필드
-                _buildTextField(
-                  '建物名、部屋番号など(任意)',
-                  '建物名、部屋番号などを入力してください',
-                  signUpState.buildingController,
-                  screenWidth,
-                  signUpViewModel,
-                  isOptional: true,  // 선택 필드로 설정
-                ),
-                SizedBox(height: screenHeight * 0.1),  // 버튼 위에 공간 추가
+              ),
+              SizedBox(height: screenHeight * 0.02), // 여백
 
-                // 아카운트 생성 버튼
-                Center(
-                  child: ElevatedButton(
-                    onPressed: signUpState.isFormValid
-                        ? () async {
-                            if (_formKey.currentState?.validate() ?? false) {
-                              _showLoadingDialog(context);  // 로딩 스피너 표시
-                              signUpViewModel.signUp(context);  // 회원가입 로직 실행
-                              await Future.delayed(Duration(seconds: 2));  // 2초 지연
-                              Navigator.pop(context);  // 로딩 스피너 닫기
-                            }
+              // '店舗名' 텍스트 필드 빌드
+              _buildTextField(
+                label: '店舗名',
+                hint: '店舗名を入力してください',
+                screenWidth: screenWidth,
+                onChanged: signUpViewModel.updateStoreName,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '店舗名を入力してください';
+                  }
+                  return null;
+                },
+              ),
+              SizedBox(height: screenHeight * 0.02), // 여백
+
+              // 이메일 입력 필드
+              _buildEmailField(
+                screenWidth: screenWidth,
+                signUpState: signUpState,
+                signUpViewModel: signUpViewModel,
+              ),
+              SizedBox(height: screenHeight * 0.02), // 여백
+
+              // 비밀번호 입력 필드
+              _buildPasswordField(
+                label: 'パスワード',
+                screenWidth: screenWidth,
+                signUpState: signUpState,
+                signUpViewModel: signUpViewModel,
+              ),
+              SizedBox(height: screenHeight * 0.02), // 여백
+
+              // 비밀번호 확인 필드
+              _buildConfirmPasswordField(
+                label: 'パスワード確認',
+                screenWidth: screenWidth,
+                signUpState: signUpState,
+                signUpViewModel: signUpViewModel,
+              ),
+              SizedBox(height: screenHeight * 0.02), // 여백
+
+              // 우편번호와 도도부현 (都道府県) 입력 필드
+              Row(
+                children: [
+                  Expanded(
+                    child: _buildTextField(
+                      label: '郵便番号',
+                      hint: '郵便番号を入力してください',
+                      screenWidth: screenWidth,
+                      onChanged: signUpViewModel.updateZipCode,
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return '郵便番号を入力してください';
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                  SizedBox(width: screenWidth * 0.02), // 우편번호와 도도부현 사이의 여백
+                  Expanded(
+                    child: _buildTextField(
+                      label: '都道府県',
+                      hint: '都道府県を入力してください',
+                      screenWidth: screenWidth,
+                      onChanged: signUpViewModel.updateState,
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return '都道府県を入力してください';
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: screenHeight * 0.02), // 여백
+
+              // 시/구/읍/면/동 입력 필드
+              _buildTextField(
+                label: '市区町村',
+                hint: '市区町村を入力してください',
+                screenWidth: screenWidth,
+                onChanged: signUpViewModel.updateCity,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '市区町村を入力してください';
+                  }
+                  return null;
+                },
+              ),
+              SizedBox(height: screenHeight * 0.02), // 여백
+
+              // 상세 주소 입력 필드
+              _buildTextField(
+                label: '住所',
+                hint: '住所を入力してください',
+                screenWidth: screenWidth,
+                onChanged: signUpViewModel.updateAddress,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '住所を入力してください';
+                  }
+                  return null;
+                },
+              ),
+              SizedBox(height: screenHeight * 0.02), // 여백
+
+              // 건물명/호실번호(선택사항) 입력 필드
+              _buildTextField(
+                label: '建物名、部屋番号など(任意)',
+                hint: '建物名、部屋番号などを入力してください',
+                screenWidth: screenWidth,
+                onChanged: signUpViewModel.updateBuilding,
+                isOptional: true, // 선택 필드로 설정
+              ),
+              SizedBox(height: screenHeight * 0.1), // 버튼 위에 공간 추가
+
+              // 아카운트 생성 버튼
+              Center(
+                child: ElevatedButton(
+                  onPressed: signUpState.isFormValid
+                      ? () async {
+                          if (_formKey.currentState?.validate() ?? false) {
+                            await signUpViewModel.signUp(); // 회원가입 로직 실행
                           }
-                        : null,  // 폼이 유효하지 않으면 버튼 비활성화
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: signUpState.isFormValid
-                          ? Color(0xFF1D2538)  // 유효할 때의 버튼 색상
-                          : Colors.grey,  // 유효하지 않을 때의 버튼 색상
-                      padding: EdgeInsets.symmetric(
-                        horizontal: screenWidth * 0.3,  // 버튼 가로 패딩
-                        vertical: screenHeight * 0.01,  // 버튼 세로 패딩
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(50),  // 버튼의 모서리 둥글게 설정
-                      ),
+                        }
+                      : null, // 폼이 유효하지 않으면 버튼 비활성화
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: signUpState.isFormValid
+                        ? Color(0xFF1D2538) // 유효할 때의 버튼 색상
+                        : Colors.grey, // 유효하지 않을 때의 버튼 색상
+                    padding: EdgeInsets.symmetric(
+                      horizontal: screenWidth * 0.3, // 버튼 가로 패딩
+                      vertical: screenHeight * 0.01, // 버튼 세로 패딩
                     ),
-                    child: Text(
-                      'アカウント作成',  // 버튼 텍스트
-                      style: TextStyle(
-                        fontSize: screenWidth * 0.045,  // 버튼 글자 크기
-                        color: Colors.white,  // 버튼 텍스트 색상
-                      ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.circular(50), // 버튼의 모서리 둥글게 설정
                     ),
                   ),
-                ),
-                SizedBox(height: screenHeight * 0.02),  // 하단 여백
-
-                // 약관 및 정책 안내 텍스트
-                Center(
                   child: Text(
-                    'アカウント作成することでサービス利用規約およびプライバシーポリシーに同意したことになります。必ず御読みください。',
-                    textAlign: TextAlign.center,
+                    'アカウント作成', // 버튼 텍스트
                     style: TextStyle(
-                      fontSize: screenWidth * 0.03,  // 텍스트 크기
-                      color: Colors.black,
+                      fontSize: screenWidth * 0.045, // 버튼 글자 크기
+                      color: Colors.white, // 버튼 텍스트 색상
                     ),
                   ),
                 ),
-              ],
-            ),
+              ),
+              SizedBox(height: screenHeight * 0.02), // 하단 여백
+
+              // 약관 및 정책 안내 텍스트
+              Center(
+                child: Text(
+                  'アカウント作成することでサービス利用規約およびプライバシーポリシーに同意したことになります。必ず御読みください。',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: screenWidth * 0.03, // 텍스트 크기
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),
     );
   }
 
-  // 로딩 스피너 다이얼로그 표시 함수
-  void _showLoadingDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      barrierDismissible: false,  // 로딩 중 다이얼로그 외부를 클릭해도 닫히지 않도록 설정
-      builder: (context) {
-        return Dialog(
-          backgroundColor: Colors.transparent,  // 다이얼로그 배경 투명
-          elevation: 0,  // 그림자 없음
-          child: Center(
-            child: CircularProgressIndicator(),  // 로딩 스피너 표시
-          ),
-        );
-      },
-    );
-  }
-
   // 텍스트 필드를 빌드하는 함수
-  Widget _buildTextField(
-    String label,  // 필드의 라벨
-    String hint,  // 힌트 텍스트
-    TextEditingController controller,  // 텍스트 입력을 제어하는 컨트롤러
-    double screenWidth,  // 화면 너비
-    OwnerSignUpViewModel signUpViewModel,  // ViewModel
-    {bool isOptional = false} // 필수 필드인지 선택 필드인지 구분하는 플래그
-  ) {
+  Widget _buildTextField({
+    required String label,
+    required String hint,
+    required double screenWidth,
+    required Function(String) onChanged,
+    String? Function(String?)? validator,
+    bool isOptional = false,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),  // 라벨 표시
-        SizedBox(height: 10),  // 라벨과 입력 필드 사이 여백
+        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),
+        SizedBox(height: 10),
         TextFormField(
-          controller: controller,  // 입력 필드에 연결된 컨트롤러
           decoration: InputDecoration(
             border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(15.0),  // 입력 필드 테두리 모서리 둥글게 설정
-              borderSide: BorderSide(color: Colors.grey),  // 테두리 색상 설정
+              borderRadius: BorderRadius.circular(15.0),
+              borderSide: BorderSide(color: Colors.grey),
             ),
-            hintText: hint,  // 힌트 텍스트 설정
+            hintText: hint,
           ),
+          validator: validator ??
+              (value) {
+                if (!isOptional && (value == null || value.isEmpty)) {
+                  return '$labelを入力してください';
+                }
+                return null;
+              },
           onChanged: (value) {
-            if (!isOptional) {
-              signUpViewModel.validateFields();  // 선택 필드가 아닌 경우 필드 검증 호출
-            }
+            onChanged(value);
           },
+          autocorrect: false,
+          enableSuggestions: false,
         ),
       ],
     );
   }
 
   // 이메일 입력 필드를 빌드하는 함수
-  Widget _buildEmailField(
-    String label,
-    TextEditingController controller,
-    double screenWidth,
-    SignUpState signUpState,
-    OwnerSignUpViewModel signUpViewModel,
-  ) {
+  Widget _buildEmailField({
+    required double screenWidth,
+    required OwnerSignUpState signUpState,
+    required OwnerSignUpViewModel signUpViewModel,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),  // 라벨 표시
-        SizedBox(height: 10),  // 라벨과 입력 필드 사이 여백
+        Text('メールアドレス', style: TextStyle(fontSize: screenWidth * 0.05)),
+        SizedBox(height: 10),
         TextFormField(
-          controller: controller,  // 이메일 입력 필드에 연결된 컨트롤러
           decoration: InputDecoration(
             border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(15.0),  // 입력 필드 테두리 둥글게 설정
+              borderRadius: BorderRadius.circular(15.0),
               borderSide: BorderSide(
-                color: signUpState.emailError != null ? Colors.red : Colors.grey,  // 에러가 있을 경우 빨간색 테두리
+                color: signUpState.emailError != null ? Colors.red : Colors.grey,
               ),
             ),
-            hintText: 'メールアドレスを入力してください',  // 이메일 입력 필드의 힌트
-            errorText: signUpState.emailError,  // 에러 메시지
+            hintText: 'メールアドレスを入力してください',
+            errorText: signUpState.emailError,
           ),
-          keyboardType: TextInputType.emailAddress,  // 이메일 입력 형식
+          keyboardType: TextInputType.emailAddress,
           onChanged: (value) {
-            signUpViewModel.validateEmail(value);  // 이메일 검증
+            signUpViewModel.updateEmail(value);
           },
+          validator: (value) {
+            if (value == null || value.isEmpty) {
+              return 'メールアドレスを入力してください';
+            }
+            if (signUpState.emailError != null) {
+              return signUpState.emailError;
+            }
+            return null;
+          },
+          autocorrect: false,
+          enableSuggestions: false,
         ),
       ],
     );
   }
 
   // 비밀번호 입력 필드를 빌드하는 함수
-  Widget _buildPasswordField(
-    String label,
-    TextEditingController controller,
-    double screenWidth,
-    SignUpState signUpState,
-    OwnerSignUpViewModel signUpViewModel,
-  ) {
-    final isVisible = signUpState.isPasswordVisible;  // 비밀번호 표시 여부
+  Widget _buildPasswordField({
+    required String label,
+    required double screenWidth,
+    required OwnerSignUpState signUpState,
+    required OwnerSignUpViewModel signUpViewModel,
+  }) {
+    final isVisible = signUpState.isPasswordVisible;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),  // 라벨 표시
-        SizedBox(height: 10),  // 라벨과 입력 필드 사이 여백
+        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),
+        SizedBox(height: 10),
         TextFormField(
-          controller: controller,  // 비밀번호 입력 필드에 연결된 컨트롤러
-          obscureText: !isVisible,  // 비밀번호 가리기 설정
+          obscureText: !isVisible,
           decoration: InputDecoration(
             border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(15.0),  // 입력 필드 테두리 둥글게 설정
-              borderSide: BorderSide(color: Colors.grey),  // 테두리 색상 설정
+              borderRadius: BorderRadius.circular(15.0),
+              borderSide: BorderSide(
+                color: signUpState.passwordError != null ? Colors.red : Colors.grey,
+              ),
             ),
-            hintText: '*********',  // 비밀번호 입력 필드의 힌트
-            errorText: signUpState.passwordError,  // 에러 메시지
+            hintText: '*********',
+            errorText: signUpState.passwordError,
             suffixIcon: IconButton(
-              icon: Icon(isVisible ? Icons.visibility : Icons.visibility_off),  // 비밀번호 표시/숨기기 아이콘
-              onPressed: signUpViewModel.togglePasswordVisibility,  // 아이콘 클릭 시 비밀번호 표시 여부 토글
+              icon: Icon(isVisible ? Icons.visibility : Icons.visibility_off),
+              onPressed: signUpViewModel.togglePasswordVisibility,
             ),
           ),
           onChanged: (value) {
-            signUpViewModel.validatePassword(value);  // 비밀번호 검증
+            signUpViewModel.updatePassword(value);
           },
+          validator: (value) {
+            if (value == null || value.isEmpty) {
+              return 'パスワードを入力してください';
+            }
+            if (signUpState.passwordError != null) {
+              return signUpState.passwordError;
+            }
+            return null;
+          },
+          autocorrect: false,
+          enableSuggestions: false,
         ),
       ],
     );
   }
 
   // 비밀번호 확인 입력 필드를 빌드하는 함수
-  Widget _buildConfirmPasswordField(
-    String label,
-    TextEditingController controller,
-    double screenWidth,
-    SignUpState signUpState,
-    OwnerSignUpViewModel signUpViewModel,
-  ) {
-    final isVisible = signUpState.isConfirmPasswordVisible;  // 비밀번호 확인 표시 여부
+  Widget _buildConfirmPasswordField({
+    required String label,
+    required double screenWidth,
+    required OwnerSignUpState signUpState,
+    required OwnerSignUpViewModel signUpViewModel,
+  }) {
+    final isVisible = signUpState.isConfirmPasswordVisible;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),  // 라벨 표시
-        SizedBox(height: 10),  // 라벨과 입력 필드 사이 여백
+        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),
+        SizedBox(height: 10),
         TextFormField(
-          controller: controller,  // 비밀번호 확인 입력 필드에 연결된 컨트롤러
-          obscureText: !isVisible,  // 비밀번호 가리기 설정
+          obscureText: !isVisible,
           decoration: InputDecoration(
             border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(15.0),  // 입력 필드 테두리 둥글게 설정
-              borderSide: BorderSide(color: Colors.grey),  // 테두리 색상 설정
+              borderRadius: BorderRadius.circular(15.0),
+              borderSide: BorderSide(
+                color: signUpState.confirmPasswordError != null
+                    ? Colors.red
+                    : Colors.grey,
+              ),
             ),
-            hintText: '*********',  // 비밀번호 확인 필드의 힌트
-            errorText: signUpState.confirmPasswordError,  // 에러 메시지
+            hintText: '*********',
+            errorText: signUpState.confirmPasswordError,
             suffixIcon: IconButton(
-              icon: Icon(isVisible ? Icons.visibility : Icons.visibility_off),  // 비밀번호 표시/숨기기 아이콘
-              onPressed: signUpViewModel.toggleConfirmPasswordVisibility,  // 아이콘 클릭 시 비밀번호 표시 여부 토글
+              icon: Icon(isVisible ? Icons.visibility : Icons.visibility_off),
+              onPressed: signUpViewModel.toggleConfirmPasswordVisibility,
             ),
           ),
           onChanged: (value) {
-            signUpViewModel.validateConfirmPassword(value);  // 비밀번호 확인 검증
+            signUpViewModel.updateConfirmPassword(value);
           },
+          validator: (value) {
+            if (value == null || value.isEmpty) {
+              return 'パスワード確認を入力してください';
+            }
+            if (signUpState.confirmPasswordError != null) {
+              return signUpState.confirmPasswordError;
+            }
+            return null;
+          },
+          autocorrect: false,
+          enableSuggestions: false,
         ),
       ],
     );

--- a/lib/view/sign-up/owner_sign_up_screen.dart
+++ b/lib/view/sign-up/owner_sign_up_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../viewModel/owner_sign_up_view_model.dart';
-import 'photo_upload_screen.dart'; // photo_upload_screen을 임포트
+import 'photo_upload_screen.dart'; // Import photo_upload_screen
 import '../../model/owner_signup_state_model.dart';
 
+/// Main Sign-Up Screen
 class OwnerSignUpScreen extends ConsumerStatefulWidget {
   @override
   _OwnerSignUpScreenState createState() => _OwnerSignUpScreenState();
@@ -19,15 +20,15 @@ class _OwnerSignUpScreenState extends ConsumerState<OwnerSignUpScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // 상태를 watch하여 변경 시 UI가 리빌드되도록 함
+    // Watch the sign-up state to rebuild UI on changes
     final signUpState = ref.watch(ownerSignUpViewModelProvider);
-    // ViewModel을 read하여 상태 변경을 수행
+    // Read the ViewModel to perform state changes
     final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
 
-    // 회원가입 성공 시 photo_upload_screen으로 이동
+    // Navigate to PhotoUploadScreen on successful sign-up
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (signUpState.signUpSuccess) {
-        print('Navigating to PhotoUploadScreen'); // 디버그 로그 추가
+        print('Navigating to PhotoUploadScreen'); // Debug log
         Navigator.push(
           context,
           MaterialPageRoute(
@@ -48,252 +49,144 @@ class _OwnerSignUpScreenState extends ConsumerState<OwnerSignUpScreen> {
       }
     });
 
-    // 화면 크기 계산을 위해 MediaQuery 사용
+    // Calculate screen size using MediaQuery
     final screenSize = MediaQuery.of(context).size;
     final screenWidth = screenSize.width;
     final screenHeight = screenSize.height;
 
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: Colors.grey),
-          onPressed: () => Navigator.pop(context), // 뒤로 가기 버튼
-        ),
-        backgroundColor: Colors.transparent, // 앱바 투명 배경
-        elevation: 0, // 그림자 없애기
-      ),
+      appBar: CustomAppBar(),
       body: SingleChildScrollView(
-        padding: EdgeInsets.all(screenWidth * 0.04), // 전체 화면 패딩 설정
+        padding: EdgeInsets.all(screenWidth * 0.04), // Set padding for the entire screen
         child: Form(
-          key: _formKey, // 폼 상태 관리
+          key: _formKey, // Manage form state
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Center(
-                child: Text(
-                  '会員登録', // 타이틀
-                  style: TextStyle(
-                    fontSize: screenWidth * 0.06, // 상대적인 글자 크기
-                    fontWeight: FontWeight.bold, // 굵은 글씨체
-                  ),
-                ),
-              ),
-              SizedBox(height: screenHeight * 0.02), // 여백
+              FormTitle(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
 
-              // '店舗名' 텍스트 필드 빌드
-              _buildTextField(
-                label: '店舗名',
-                hint: '店舗名を入力してください',
-                screenWidth: screenWidth,
-                onChanged: signUpViewModel.updateStoreName,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return '店舗名を入力してください';
+              StoreNameField(screenWidth: screenWidth, signUpViewModel: signUpViewModel),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              EmailField(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              PasswordField(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              ConfirmPasswordField(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              AddressFields(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              CityField(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              AddressField(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              BuildingField(screenWidth: screenWidth, signUpViewModel: signUpViewModel),
+              SizedBox(height: screenHeight * 0.1), // Extra space above the button
+
+              SubmitButton(
+                isFormValid: signUpState.isFormValid,
+                onPressed: () async {
+                  if (_formKey.currentState?.validate() ?? false) {
+                    await signUpViewModel.signUp(); // Execute sign-up logic
                   }
-                  return null;
                 },
-              ),
-              SizedBox(height: screenHeight * 0.02), // 여백
-
-              // 이메일 입력 필드
-              _buildEmailField(
                 screenWidth: screenWidth,
-                signUpState: signUpState,
-                signUpViewModel: signUpViewModel,
+                screenHeight: screenHeight,
               ),
-              SizedBox(height: screenHeight * 0.02), // 여백
+              SizedBox(height: screenHeight * 0.02), // Bottom spacer
 
-              // 비밀번호 입력 필드
-              _buildPasswordField(
-                label: 'パスワード',
-                screenWidth: screenWidth,
-                signUpState: signUpState,
-                signUpViewModel: signUpViewModel,
-              ),
-              SizedBox(height: screenHeight * 0.02), // 여백
-
-              // 비밀번호 확인 필드
-              _buildConfirmPasswordField(
-                label: 'パスワード確認',
-                screenWidth: screenWidth,
-                signUpState: signUpState,
-                signUpViewModel: signUpViewModel,
-              ),
-              SizedBox(height: screenHeight * 0.02), // 여백
-
-              // 우편번호와 도도부현 (都道府県) 입력 필드
-              Row(
-                children: [
-                  Expanded(
-                    child: _buildTextField(
-                      label: '郵便番号',
-                      hint: '郵便番号を入力してください',
-                      screenWidth: screenWidth,
-                      onChanged: signUpViewModel.updateZipCode,
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return '郵便番号を入力してください';
-                        }
-                        return null;
-                      },
-                    ),
-                  ),
-                  SizedBox(width: screenWidth * 0.02), // 우편번호와 도도부현 사이의 여백
-                  Expanded(
-                    child: _buildTextField(
-                      label: '都道府県',
-                      hint: '都道府県を入力してください',
-                      screenWidth: screenWidth,
-                      onChanged: signUpViewModel.updateState,
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return '都道府県を入力してください';
-                        }
-                        return null;
-                      },
-                    ),
-                  ),
-                ],
-              ),
-              SizedBox(height: screenHeight * 0.02), // 여백
-
-              // 시/구/읍/면/동 입력 필드
-              _buildTextField(
-                label: '市区町村',
-                hint: '市区町村を入力してください',
-                screenWidth: screenWidth,
-                onChanged: signUpViewModel.updateCity,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return '市区町村を入力してください';
-                  }
-                  return null;
-                },
-              ),
-              SizedBox(height: screenHeight * 0.02), // 여백
-
-              // 상세 주소 입력 필드
-              _buildTextField(
-                label: '住所',
-                hint: '住所を入力してください',
-                screenWidth: screenWidth,
-                onChanged: signUpViewModel.updateAddress,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return '住所を入力してください';
-                  }
-                  return null;
-                },
-              ),
-              SizedBox(height: screenHeight * 0.02), // 여백
-
-              // 건물명/호실번호(선택사항) 입력 필드
-              _buildTextField(
-                label: '建物名、部屋番号など(任意)',
-                hint: '建物名、部屋番号などを入力してください',
-                screenWidth: screenWidth,
-                onChanged: signUpViewModel.updateBuilding,
-                isOptional: true, // 선택 필드로 설정
-              ),
-              SizedBox(height: screenHeight * 0.1), // 버튼 위에 공간 추가
-
-              // 아카운트 생성 버튼
-              Center(
-                child: ElevatedButton(
-                  onPressed: signUpState.isFormValid
-                      ? () async {
-                          if (_formKey.currentState?.validate() ?? false) {
-                            await signUpViewModel.signUp(); // 회원가입 로직 실행
-                          }
-                        }
-                      : null, // 폼이 유효하지 않으면 버튼 비활성화
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: signUpState.isFormValid
-                        ? Color(0xFF1D2538) // 유효할 때의 버튼 색상
-                        : Colors.grey, // 유효하지 않을 때의 버튼 색상
-                    padding: EdgeInsets.symmetric(
-                      horizontal: screenWidth * 0.3, // 버튼 가로 패딩
-                      vertical: screenHeight * 0.01, // 버튼 세로 패딩
-                    ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius:
-                          BorderRadius.circular(50), // 버튼의 모서리 둥글게 설정
-                    ),
-                  ),
-                  child: Text(
-                    'アカウント作成', // 버튼 텍스트
-                    style: TextStyle(
-                      fontSize: screenWidth * 0.045, // 버튼 글자 크기
-                      color: Colors.white, // 버튼 텍스트 색상
-                    ),
-                  ),
-                ),
-              ),
-              SizedBox(height: screenHeight * 0.02), // 하단 여백
-
-              // 약관 및 정책 안내 텍스트
-              Center(
-                child: Text(
-                  'アカウント作成することでサービス利用規約およびプライバシーポリシーに同意したことになります。必ず御読みください。',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: screenWidth * 0.03, // 텍스트 크기
-                    color: Colors.black,
-                  ),
-                ),
-              ),
+              TermsText(screenWidth: screenWidth),
             ],
           ),
         ),
       ),
     );
   }
+}
 
-  // 텍스트 필드를 빌드하는 함수
-  Widget _buildTextField({
-    required String label,
-    required String hint,
-    required double screenWidth,
-    required Function(String) onChanged,
-    String? Function(String?)? validator,
-    bool isOptional = false,
-  }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),
-        SizedBox(height: 10),
-        TextFormField(
-          decoration: InputDecoration(
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(15.0),
-              borderSide: BorderSide(color: Colors.grey),
-            ),
-            hintText: hint,
-          ),
-          validator: validator ??
-              (value) {
-                if (!isOptional && (value == null || value.isEmpty)) {
-                  return '$labelを入力してください';
-                }
-                return null;
-              },
-          onChanged: (value) {
-            onChanged(value);
-          },
-          autocorrect: false,
-          enableSuggestions: false,
-        ),
-      ],
+/// Custom AppBar Widget
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      leading: IconButton(
+        icon: Icon(Icons.arrow_back, color: Colors.grey),
+        onPressed: () => Navigator.pop(context), // Back button
+      ),
+      backgroundColor: Colors.transparent, // Transparent AppBar
+      elevation: 0, // Remove shadow
     );
   }
 
-  // 이메일 입력 필드를 빌드하는 함수
-  Widget _buildEmailField({
-    required double screenWidth,
-    required OwnerSignUpState signUpState,
-    required OwnerSignUpViewModel signUpViewModel,
-  }) {
+  @override
+  Size get preferredSize => Size.fromHeight(kToolbarHeight);
+}
+
+/// Form Title Widget
+class FormTitle extends StatelessWidget {
+  final double screenWidth;
+
+  const FormTitle({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        '会員登録', // Title
+        style: TextStyle(
+          fontSize: screenWidth * 0.06, // Relative font size
+          fontWeight: FontWeight.bold, // Bold font
+        ),
+      ),
+    );
+  }
+}
+
+/// Store Name Field Widget
+class StoreNameField extends ConsumerWidget {
+  final double screenWidth;
+  final OwnerSignUpViewModel signUpViewModel;
+
+  const StoreNameField({
+    required this.screenWidth,
+    required this.signUpViewModel,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CustomTextField(
+      label: '店舗名',
+      hint: '店舗名を入力してください',
+      screenWidth: screenWidth,
+      onChanged: signUpViewModel.updateStoreName,
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return '店舗名を入力してください';
+        }
+        return null;
+      },
+    );
+  }
+}
+
+/// Email Field Widget
+class EmailField extends ConsumerWidget {
+  final double screenWidth;
+
+  const EmailField({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpState = ref.watch(ownerSignUpViewModelProvider);
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -329,20 +222,24 @@ class _OwnerSignUpScreenState extends ConsumerState<OwnerSignUpScreen> {
       ],
     );
   }
+}
 
-  // 비밀번호 입력 필드를 빌드하는 함수
-  Widget _buildPasswordField({
-    required String label,
-    required double screenWidth,
-    required OwnerSignUpState signUpState,
-    required OwnerSignUpViewModel signUpViewModel,
-  }) {
+/// Password Field Widget
+class PasswordField extends ConsumerWidget {
+  final double screenWidth;
+
+  const PasswordField({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpState = ref.watch(ownerSignUpViewModelProvider);
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
     final isVisible = signUpState.isPasswordVisible;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),
+        Text('パスワード', style: TextStyle(fontSize: screenWidth * 0.05)),
         SizedBox(height: 10),
         TextFormField(
           obscureText: !isVisible,
@@ -378,20 +275,24 @@ class _OwnerSignUpScreenState extends ConsumerState<OwnerSignUpScreen> {
       ],
     );
   }
+}
 
-  // 비밀번호 확인 입력 필드를 빌드하는 함수
-  Widget _buildConfirmPasswordField({
-    required String label,
-    required double screenWidth,
-    required OwnerSignUpState signUpState,
-    required OwnerSignUpViewModel signUpViewModel,
-  }) {
+/// Confirm Password Field Widget
+class ConfirmPasswordField extends ConsumerWidget {
+  final double screenWidth;
+
+  const ConfirmPasswordField({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpState = ref.watch(ownerSignUpViewModelProvider);
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
     final isVisible = signUpState.isConfirmPasswordVisible;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),
+        Text('パスワード確認', style: TextStyle(fontSize: screenWidth * 0.05)),
         SizedBox(height: 10),
         TextFormField(
           obscureText: !isVisible,
@@ -399,9 +300,7 @@ class _OwnerSignUpScreenState extends ConsumerState<OwnerSignUpScreen> {
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(15.0),
               borderSide: BorderSide(
-                color: signUpState.confirmPasswordError != null
-                    ? Colors.red
-                    : Colors.grey,
+                color: signUpState.confirmPasswordError != null ? Colors.red : Colors.grey,
               ),
             ),
             hintText: '*********',
@@ -422,6 +321,240 @@ class _OwnerSignUpScreenState extends ConsumerState<OwnerSignUpScreen> {
               return signUpState.confirmPasswordError;
             }
             return null;
+          },
+          autocorrect: false,
+          enableSuggestions: false,
+        ),
+      ],
+    );
+  }
+}
+
+/// Address Fields Widget (Zip Code and Prefecture)
+class AddressFields extends ConsumerWidget {
+  final double screenWidth;
+
+  const AddressFields({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+    final signUpState = ref.watch(ownerSignUpViewModelProvider);
+
+    return Row(
+      children: [
+        Expanded(
+          child: CustomTextField(
+            label: '郵便番号',
+            hint: '郵便番号を入力してください',
+            screenWidth: screenWidth,
+            onChanged: signUpViewModel.updateZipCode,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return '郵便番号を入力してください';
+              }
+              return null;
+            },
+          ),
+        ),
+        SizedBox(width: screenWidth * 0.02), // Spacer between Zip Code and Prefecture
+        Expanded(
+          child: CustomTextField(
+            label: '都道府県',
+            hint: '都道府県を入力してください',
+            screenWidth: screenWidth,
+            onChanged: signUpViewModel.updateState,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return '都道府県を入力してください';
+              }
+              return null;
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// City Field Widget
+class CityField extends ConsumerWidget {
+  final double screenWidth;
+
+  const CityField({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
+    return CustomTextField(
+      label: '市区町村',
+      hint: '市区町村を入力してください',
+      screenWidth: screenWidth,
+      onChanged: signUpViewModel.updateCity,
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return '市区町村を入力してください';
+        }
+        return null;
+      },
+    );
+  }
+}
+
+/// Address Field Widget
+class AddressField extends ConsumerWidget {
+  final double screenWidth;
+
+  const AddressField({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
+    return CustomTextField(
+      label: '住所',
+      hint: '住所を入力してください',
+      screenWidth: screenWidth,
+      onChanged: signUpViewModel.updateAddress,
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return '住所を入力してください';
+        }
+        return null;
+      },
+    );
+  }
+}
+
+/// Building Field Widget (Optional)
+class BuildingField extends StatelessWidget {
+  final double screenWidth;
+  final OwnerSignUpViewModel signUpViewModel;
+
+  const BuildingField({
+    required this.screenWidth,
+    required this.signUpViewModel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomTextField(
+      label: '建物名、部屋番号など(任意)',
+      hint: '建物名、部屋番号などを入力してください',
+      screenWidth: screenWidth,
+      onChanged: signUpViewModel.updateBuilding,
+      isOptional: true, // Mark as optional
+    );
+  }
+}
+
+/// Submit Button Widget
+class SubmitButton extends StatelessWidget {
+  final bool isFormValid;
+  final VoidCallback onPressed;
+  final double screenWidth;
+  final double screenHeight;
+
+  const SubmitButton({
+    required this.isFormValid,
+    required this.onPressed,
+    required this.screenWidth,
+    required this.screenHeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: isFormValid ? onPressed : null, // Disable if form is invalid
+        style: ElevatedButton.styleFrom(
+          backgroundColor: isFormValid
+              ? Color(0xFF1D2538) // Button color when valid
+              : Colors.grey, // Button color when invalid
+          padding: EdgeInsets.symmetric(
+            horizontal: screenWidth * 0.3, // Horizontal padding
+            vertical: screenHeight * 0.01, // Vertical padding
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(50), // Rounded corners
+          ),
+        ),
+        child: Text(
+          'アカウント作成', // Button text
+          style: TextStyle(
+            fontSize: screenWidth * 0.045, // Font size
+            color: Colors.white, // Text color
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Terms and Conditions Text Widget
+class TermsText extends StatelessWidget {
+  final double screenWidth;
+
+  const TermsText({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        'アカウント作成することでサービス利用規約およびプライバシーポリシーに同意したことになります。必ず御読みください。',
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: screenWidth * 0.03, // Text size
+          color: Colors.black,
+        ),
+      ),
+    );
+  }
+}
+
+/// Custom Text Field Widget
+class CustomTextField extends StatelessWidget {
+  final String label;
+  final String hint;
+  final double screenWidth;
+  final Function(String) onChanged;
+  final String? Function(String?)? validator;
+  final bool isOptional;
+
+  const CustomTextField({
+    required this.label,
+    required this.hint,
+    required this.screenWidth,
+    required this.onChanged,
+    this.validator,
+    this.isOptional = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),
+        SizedBox(height: 10),
+        TextFormField(
+          decoration: InputDecoration(
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(15.0),
+              borderSide: BorderSide(color: Colors.grey),
+            ),
+            hintText: hint,
+          ),
+          validator: validator ??
+              (value) {
+                if (!isOptional && (value == null || value.isEmpty)) {
+                  return '$labelを入力してください';
+                }
+                return null;
+              },
+          onChanged: (value) {
+            onChanged(value);
           },
           autocorrect: false,
           enableSuggestions: false,

--- a/lib/view/sign-up/photo_upload_screen.dart
+++ b/lib/view/sign-up/photo_upload_screen.dart
@@ -36,8 +36,11 @@ class _PhotoUploadScreenState extends ConsumerState<PhotoUploadScreen> {
     final screenWidth = screenSize.width;
     final screenHeight = screenSize.height;
 
-    return WillPopScope(
-      onWillPop: () async => false, // 뒤로 가기 방지
+    return PopScope<Object?>(
+      canPop: false, // 뒤로 가기 제스처 및 버튼을 막음
+      onPopInvokedWithResult: (bool didPop, Object? result) {
+        // 뒤로 가기 동작을 하지 않도록 막음 (아무 동작도 하지 않음)
+      },
       child: Scaffold(
         appBar: AppBar(
           leading: IconButton(

--- a/lib/view/tab/owner/owner_home_screen.dart
+++ b/lib/view/tab/owner/owner_home_screen.dart
@@ -8,6 +8,9 @@ import 'point_management_confirm_screen.dart';
 import 'meber_input_screen.dart';
 import 'owner_transaction_history_screen.dart';
 import '../event_home.dart';
+import 'point_limit_screen.dart';
+import '../privacy_policy_screen.dart';
+import '../terms_of_service_screen.dart';
 
 class OwnerHomeScreen extends ConsumerWidget {
   @override
@@ -21,7 +24,7 @@ class OwnerHomeScreen extends ConsumerWidget {
       OwnerTransactionHistoryScreen(),
       ScanTabNavigator(), // QR 코드 스캔 및 포인트 관리 페이지
       AccountTab(),
-      OwnerSettingsTab(),
+      OwnerSettings(),
     ];
 
     return Scaffold(
@@ -88,6 +91,35 @@ class ScanTabNavigator extends StatelessWidget {
           default:
             return MaterialPageRoute(
               builder: (context) => ScanTab(),
+            );
+        }
+      },
+    );
+  }
+}
+
+class OwnerSettings extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      initialRoute: '/', // 초기 경로 설정
+      onGenerateRoute: (settings) {
+        switch (settings.name) {
+          case '/pointLimit':
+            return MaterialPageRoute(
+              builder: (context) => PointLimitScreen(),
+            );
+          case '/privacyPolicy': // PrivacyPolicyScreen으로 이동하는 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => PrivacyPolicyScreen(),
+            );
+          case '/termsOfservice': // TermsOfServiceScreen으로 이동하는 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => TermsOfServiceScreen(),
+            );
+          default:
+            return MaterialPageRoute(
+              builder: (context) => OwnerSettingsTab(),
             );
         }
       },

--- a/lib/view/tab/owner/point_limit_screen.dart
+++ b/lib/view/tab/owner/point_limit_screen.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart'; // 숫자 포맷팅을 위해 추가
+import '../../../viewModel/owner_settings_tab_view_model.dart'; // Firestore 데이터 연동
+
+class PointLimitScreen extends ConsumerWidget {
+  PointLimitScreen();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    // Firestore 데이터 연동 (현재 포인트 리미트 상태)
+    final pointLimitState = ref.watch(ownerSettingProvider);
+    final pointLimitNotifier = ref.read(ownerSettingProvider.notifier);
+
+    // 기본값이 null일 경우 0으로 초기화
+    final transactionAmount = pointLimitState ?? 0;
+
+    // 숫자 포맷팅: 세 자리마다 쉼표
+    final formattedTransactionAmount =
+        NumberFormat("#,###").format(transactionAmount);
+
+    return Scaffold(
+      backgroundColor: Colors.white, // 배경 색상 설정
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 상단 텍스트
+          const _TopTitle(),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end, // 나머지 컴포넌트를 아래로 정렬
+              children: [
+                _PointDisplay(
+                  formattedTransactionAmount: formattedTransactionAmount,
+                  screenWidth: screenWidth,
+                ),
+                _NumberDial(
+                  transactionAmount: transactionAmount,
+                  pointLimitNotifier: pointLimitNotifier,
+                  screenWidth: screenWidth,
+                  screenHeight: screenHeight,
+                ),
+                _SubmitButton(
+                  transactionAmount: transactionAmount,
+                  pointLimitNotifier: pointLimitNotifier,
+                  screenWidth: screenWidth,
+                  screenHeight: screenHeight,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TopTitle extends StatelessWidget {
+  const _TopTitle();
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        top: screenHeight * 0.08,
+        left: screenWidth * 0.05,
+      ), // 화면 높이의 5%만큼 상단 여백
+      child: Text(
+        'ポイント管理',
+        style: TextStyle(
+          color: Colors.black,
+          fontSize: screenWidth * 0.06, // 텍스트 크기 화면 너비의 7%
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+class _PointDisplay extends StatelessWidget {
+  final String formattedTransactionAmount;
+  final double screenWidth;
+
+  const _PointDisplay({
+    required this.formattedTransactionAmount,
+    required this.screenWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.bottomRight,
+      child: Padding(
+        padding: EdgeInsets.only(
+          right: screenWidth * 0.05,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            Text(
+              formattedTransactionAmount,
+              style: TextStyle(
+                fontSize: screenWidth * 0.06,
+                fontWeight: FontWeight.bold,
+                color: Colors.black,
+              ),
+            ),
+            SizedBox(width: 4), // 숫자와 pt 사이 간격
+            Text(
+              'pt',
+              style: TextStyle(
+                fontSize: screenWidth * 0.04, // 숫자보다 작게 설정
+                fontWeight: FontWeight.normal,
+                color: Colors.grey,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NumberDial extends StatelessWidget {
+  final int transactionAmount;
+  final OwnerSettingsTabViewModel pointLimitNotifier;
+  final double screenWidth;
+  final double screenHeight;
+
+  const _NumberDial({
+    required this.transactionAmount,
+    required this.pointLimitNotifier,
+    required this.screenWidth,
+    required this.screenHeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: screenWidth * 0.05,
+      ), // 좌우 여백 설정
+      child: Container(
+        height: screenHeight * 0.4,
+        child: GridView.builder(
+          itemCount: 12,
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 3,
+            crossAxisSpacing: screenWidth * 0.012, // 좌우 버튼 간격 축소
+            mainAxisSpacing: screenHeight * 0.005,
+            childAspectRatio: 2,
+          ),
+          physics: NeverScrollableScrollPhysics(),
+          itemBuilder: (context, index) {
+            String displayText;
+
+            if (index == 9) {
+              displayText = 'C'; // 초기화 버튼
+            } else if (index == 11) {
+              displayText = ''; // 백스페이스 버튼
+            } else {
+              displayText = index == 10 ? '0' : '${index + 1}'; // 숫자 버튼
+            }
+
+            return GestureDetector(
+              onTap: () {
+                if (displayText == 'C') {
+                  pointLimitNotifier.setPointLimit(0); // Firestore 호출 없이 상태 변경
+                } else if (index == 11) {
+                  final currentAmount = transactionAmount.toString();
+                  final newAmount = currentAmount.length > 1
+                      ? currentAmount.substring(0, currentAmount.length - 1)
+                      : '0';
+                  pointLimitNotifier.setPointLimit(int.parse(newAmount));
+                } else {
+                  final currentAmount = transactionAmount.toString();
+                  final newAmountStr = currentAmount == '0'
+                      ? displayText
+                      : currentAmount + displayText;
+                  if (newAmountStr.length <= 9) {
+                    pointLimitNotifier.setPointLimit(int.parse(newAmountStr));
+                  }
+                }
+              },
+              child: Container(
+                margin: EdgeInsets.all(screenWidth * 0.01),
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade200,
+                  borderRadius: BorderRadius.circular(screenWidth * 0.02),
+                ),
+                child: Center(
+                  child: index == 11
+                      ? Icon(Icons.backspace,
+                          size: screenWidth * 0.07) // 백스페이스 아이콘
+                      : Text(
+                          displayText,
+                          style: TextStyle(
+                            fontSize: screenWidth * 0.05,
+                            color: Colors.black,
+                          ),
+                        ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _SubmitButton extends StatelessWidget {
+  final int transactionAmount;
+  final OwnerSettingsTabViewModel pointLimitNotifier;
+  final double screenWidth;
+  final double screenHeight;
+
+  const _SubmitButton({
+    required this.transactionAmount,
+    required this.pointLimitNotifier,
+    required this.screenWidth,
+    required this.screenHeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: screenWidth * 0.1,
+        vertical: screenHeight * 0.02,
+      ),
+      child: ElevatedButton(
+        onPressed: transactionAmount > 0
+            ? () async {
+                await pointLimitNotifier.updatePointLimit(transactionAmount);
+                print('새로운 한도: $transactionAmount pt');
+                Navigator.pop(context);
+              }
+            : null,
+        style: ElevatedButton.styleFrom(
+          padding: EdgeInsets.symmetric(
+              vertical: screenHeight * 0.015), // 버튼 높이 조절
+          backgroundColor: transactionAmount > 0
+              ? Color(0xFF1E1E2C)
+              : Colors.grey.shade400, // 비활성화 색상
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(30), // 둥근 모서리
+          ),
+          fixedSize: Size(screenWidth * 0.8, 50), // 버튼 길이와 높이 설정
+          elevation: 0, // 그림자 제거
+        ),
+        child: Center(
+          child: Text(
+            '確認',
+            style: TextStyle(
+              fontSize: screenWidth * 0.045, // 텍스트 크기
+              fontWeight: FontWeight.bold, // 텍스트 굵기
+              color: Colors.white, // 텍스트 색상
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/tab/owner/point_management_screen.dart
+++ b/lib/view/tab/owner/point_management_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart'; // For number formatting
 import 'package:qrr_project/viewModel/qrcode_scan_view_model.dart';
-import '../../../viewModel/point_management_view_model.dart';
+import '../../../viewModel/point_management_view_model.dart'; // 올바른 ViewModel 경로 사용
 
 class PointManagementScreen extends ConsumerStatefulWidget {
   @override
@@ -13,8 +13,10 @@ class _PointManagementScreenState extends ConsumerState<PointManagementScreen> {
   @override
   void initState() {
     super.initState();
-    // 초기 상태에서 fetchUserNameandEmail 호출 사용자의 이름과 정보 가져오기
-    ref.read(transactionProvider.notifier).fetchUserData(ref);
+    // 초기 상태에서 fetchUserData 호출하여 사용자의 이름과 정보 가져오기
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(transactionProvider.notifier).fetchUserData(ref);
+    });
   }
 
   @override
@@ -259,13 +261,13 @@ class _PointManagementScreenState extends ConsumerState<PointManagementScreen> {
                     Expanded(
                       child: GestureDetector(
                         onTap: () async {
-                          final isSuccess = await ref.read(transactionProvider.notifier).updateUserPoints(ref);
-                          if (isSuccess) {
+                          final errorMessage = await ref.read(transactionProvider.notifier).updateUserPoints(ref);
+                          if (errorMessage == null) {
                             Navigator.pushNamed(context, '/pointManagementConfirm');
                           } else {
-                            // 포인트 부족 또는 오류 시 Snackbar 표시
+                            // 포인트 부족 또는 오류 시 SnackBar 표시
                             ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text('ポイントが不足しています。')),
+                              SnackBar(content: Text(errorMessage)),
                             );
                           }
                         },

--- a/lib/view/tab/privacy_policy_screen.dart
+++ b/lib/view/tab/privacy_policy_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+class PrivacyPolicyScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'フライバシーポリシー',
+          style: TextStyle(
+            fontSize: screenWidth * 0.05,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+        centerTitle: true,
+        elevation: 1.0,
+      ),
+      body: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: screenWidth * 0.05,
+          vertical: screenHeight * 0.02,
+        ),
+        child: ListView(
+          children: [
+            _buildSection(
+              title: "1. Types data we collect",
+              content:
+                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.",
+              screenWidth: screenWidth,
+            ),
+            SizedBox(height: screenHeight * 0.02),
+            _buildSection(
+              title: "2. Use of your personal data",
+              content:
+                  "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae.\n\nNemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.",
+              screenWidth: screenWidth,
+            ),
+            SizedBox(height: screenHeight * 0.02),
+            _buildSection(
+              title: "3. Disclosure of your personal data",
+              content:
+                  "At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.\n\nEt harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus.",
+              screenWidth: screenWidth,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection({required String title, required String content, required double screenWidth}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: screenWidth * 0.045,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        SizedBox(height: screenWidth * 0.02),
+        Text(
+          content,
+          style: TextStyle(
+            fontSize: screenWidth * 0.04,
+            height: 1.5,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/tab/terms_of_service_screen.dart
+++ b/lib/view/tab/terms_of_service_screen.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+class TermsOfServiceScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          '利用規約',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: screenWidth * 0.05,
+          vertical: 16.0,
+        ),
+        child: ListView(
+          children: [
+            _buildSection(
+              title: '1. Types data we collect',
+              content:
+                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.',
+              screenWidth: screenWidth,
+            ),
+            _buildSection(
+              title: '2. Use of your personal data',
+              content:
+                  'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae.\n\nNemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.',
+              screenWidth: screenWidth,
+            ),
+            _buildSection(
+              title: '3. Disclosure of your personal data',
+              content:
+                  'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.\n\nEt harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est.',
+              screenWidth: screenWidth,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection({
+    required String title,
+    required String content,
+    required double screenWidth,
+  }) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: 16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: screenWidth * 0.045,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          SizedBox(height: 8.0),
+          Text(
+            content,
+            style: TextStyle(
+              fontSize: screenWidth * 0.04,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/tab/user/user_home_screen.dart
+++ b/lib/view/tab/user/user_home_screen.dart
@@ -11,6 +11,8 @@ import '../event_home.dart';
 import 'user_account_screen.dart';
 import 'verify_password_screen.dart'; // 비밀번호 확인 화면 추가
 import 'update_pubid_screen.dart';
+import '../privacy_policy_screen.dart';
+import '../terms_of_service_screen.dart';
 
 // UserHomeScreen 클래스는 ConsumerWidget을 사용하여 상태 관리
 class UserHomeScreen extends ConsumerWidget {
@@ -25,7 +27,7 @@ class UserHomeScreen extends ConsumerWidget {
       UserTransactionHistoryScreen(),
       QrTabNavigator(), // QR 코드 스캔 및 포인트 관리 페이지
       UserAccountNavigator(), // UserAccountNavigator로 교체
-      UserSettingsTab(),
+      UserSettingsNavigator(),
     ];
 
     return Scaffold(
@@ -117,6 +119,31 @@ class UserAccountNavigator extends StatelessWidget {
           default:
             return MaterialPageRoute(
               builder: (context) => UserAccountScreen(), // 기본 UserAccountScreen
+            );
+        }
+      },
+    );
+  }
+}
+
+// UserSettingsTab을 위한 Navigator
+class UserSettingsNavigator extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      onGenerateRoute: (settings) {
+        switch (settings.name) {
+          case '/privacyPolicy': // PrivacyPolicyScreen으로 이동하는 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => PrivacyPolicyScreen(),
+            );
+          case '/termsOfservice': // PrivacyPolicyScreen으로 이동하는 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => TermsOfServiceScreen(),
+            );
+          default:
+            return MaterialPageRoute(
+              builder: (context) => UserSettingsTab(), // 기본 UserSettingsTab
             );
         }
       },

--- a/lib/viewModel/owner_settings_tab_view_model.dart
+++ b/lib/viewModel/owner_settings_tab_view_model.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../services/preferences_manager.dart'; // PreferencesManager import
+
+class OwnerSettingsTabViewModel extends StateNotifier<int?> {
+  OwnerSettingsTabViewModel() : super(null) {
+    _fetchPointLimit();
+  }
+
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  String? _ownerDocumentId; // 업데이트 시 사용할 문서 ID 저장
+
+  // Firestore에서 포인트 리미트를 가져오기
+  Future<void> _fetchPointLimit() async {
+    try {
+      final ownerEmail = PreferencesManager.instance.getEmail();
+      if (ownerEmail == null) {
+        print('Owner email is null.');
+        return;
+      }
+
+      // 'owners' 컬렉션에서 'email' 필드가 ownerEmail과 일치하는 문서 검색
+      final querySnapshot = await _firestore
+          .collection('owners')
+          .where('email', isEqualTo: ownerEmail)
+          .get();
+
+      if (querySnapshot.docs.isNotEmpty) {
+        final doc = querySnapshot.docs.first;
+        _ownerDocumentId = doc.id; // 문서 ID 저장 (업데이트 시 사용)
+        state = doc.data()['pointLimit'] as int?;
+      } else {
+        print('No owner found with email $ownerEmail.');
+        // 필요한 경우 여기에서 추가 처리를 할 수 있습니다.
+      }
+    } catch (e) {
+      print('Error fetching point limit: $e');
+    }
+  }
+
+  // Firestore에 포인트 리미트를 업데이트 (submit 버튼 클릭 시 호출)
+  Future<void> updatePointLimit(int newLimit) async {
+    try {
+      if (_ownerDocumentId == null) {
+        print('Owner document ID is null.');
+        return;
+      }
+
+      await _firestore.collection('owners').doc(_ownerDocumentId).set({
+        'pointLimit': newLimit,
+      }, SetOptions(merge: true));
+      state = newLimit; // Firestore 업데이트 후 상태도 업데이트
+    } catch (e) {
+      print('Error updating point limit: $e');
+    }
+  }
+
+  // 상태만 변경하는 함수 (Firestore 호출 없이 사용)
+  void setPointLimit(int newLimit) {
+    state = newLimit;
+  }
+}
+
+// Riverpod Provider
+final ownerSettingProvider =
+    StateNotifierProvider<OwnerSettingsTabViewModel, int?>(
+  (ref) {
+    return OwnerSettingsTabViewModel();
+  },
+);

--- a/lib/viewModel/photo_upload_view_model.dart
+++ b/lib/viewModel/photo_upload_view_model.dart
@@ -1,165 +1,132 @@
-import 'dart:io'; // File 처리에 필요한 라이브러리
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Riverpod 상태 관리를 위한 라이브러리
-import 'package:image_picker/image_picker.dart'; // 이미지 선택 기능을 위한 라이브러리
-import 'package:firebase_storage/firebase_storage.dart'; // Firebase Storage를 사용하여 이미지 업로드
-import 'package:cloud_firestore/cloud_firestore.dart'; // Firebase Firestore를 사용하여 데이터를 저장
-import '../model/photo_upload_model.dart'; // PhotoUpload 모델 가져오기
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../model/photo_upload_state_model.dart'; // 수정된 PhotoUploadState를 import
+import '../model/photo_upload_model.dart'; // 수정된 PhotoUpload 모델
 
-/// [PhotoUploadState]는 이미지 업로드 화면에서 사용되는 상태를 정의하는 클래스입니다.
-/// - storeImages: 선택된 가게 이미지 리스트 (최대 3개)
-/// - storeLogo: 선택된 로고 이미지
-/// - message: 가게 설명 메시지
-/// - isLoading: 업로드 중인지 여부
-/// - uploadError: 업로드 실패 시 에러 메시지
-class PhotoUploadState {
-  final List<XFile?> storeImages; // 3개의 이미지 슬롯
-  final XFile? storeLogo; // 로고 이미지
-  final String message; // 가게 설명 메시지
-  final bool isLoading; // 업로드 중인지 확인
-  final String? uploadError; // 업로드 실패 시 에러 메시지
-
-  PhotoUploadState({
-    required this.storeImages,
-    required this.storeLogo,
-    required this.message,
-    this.isLoading = false,
-    this.uploadError,
-  });
-
-  /// 상태를 복사하여 새로운 상태를 반환하는 메서드
-  PhotoUploadState copyWith({
-    List<XFile?>? storeImages,
-    XFile? storeLogo,
-    String? message,
-    bool? isLoading,
-    String? uploadError,
-  }) {
-    return PhotoUploadState(
-      storeImages: storeImages ?? this.storeImages,
-      storeLogo: storeLogo ?? this.storeLogo,
-      message: message ?? this.message,
-      isLoading: isLoading ?? this.isLoading,
-      uploadError: uploadError,
-    );
-  }
-}
-
-/// [PhotoUploadViewModel]은 사진 업로드 화면에서 로직을 관리하는 ViewModel입니다.
 class PhotoUploadViewModel extends StateNotifier<PhotoUploadState> {
-  final FirebaseStorage _storage = FirebaseStorage.instance; // Firebase Storage 인스턴스
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance; // Firebase Firestore 인스턴스
-  final ImagePicker _picker = ImagePicker(); // 갤러리에서 이미지를 선택하기 위한 ImagePicker 인스턴스
+  final FirebaseStorage _storage = FirebaseStorage.instance;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final ImagePicker _picker = ImagePicker();
+  final TextEditingController _messageController = TextEditingController();
+
+  @override
+  void dispose() {
+    _messageController.dispose(); // 컨트롤러 해제
+    super.dispose();
+  }
 
   PhotoUploadViewModel()
       : super(
           PhotoUploadState(
-            storeImages: List<XFile?>.filled(3, null), // 이미지 슬롯 3개를 null로 초기화
-            storeLogo: null, // 로고 이미지도 null로 초기화
-            message: '', // 설명 메시지는 빈 문자열로 초기화
+            storeImages: List<XFile?>.filled(3, null),
+            storeLogo: null,
+            message: '',
           ),
         );
 
-  /// 이미지를 선택하고 상태를 업데이트하는 메서드
-  /// [index]: 이미지 슬롯의 인덱스 (0 ~ 2), [isLogo]: 로고를 선택하는지 여부
+  void setOwnerEmail(String email) {
+    state = state.copyWith(ownerEmail: email);
+  }
+
   Future<void> pickImage(int index, {bool isLogo = false}) async {
-    final pickedFile = await _picker.pickImage(source: ImageSource.gallery); // 갤러리에서 이미지 선택
+    final pickedFile = await _picker.pickImage(source: ImageSource.gallery);
     if (pickedFile != null) {
       if (isLogo) {
-        // 로고 이미지가 선택된 경우
-        state = state.copyWith(storeLogo: pickedFile); // 상태 업데이트
+        state = state.copyWith(storeLogo: pickedFile);
       } else {
-        // 일반 가게 이미지가 선택된 경우
-        List<XFile?> updatedImages = List.from(state.storeImages); // 기존 이미지를 복사
-        updatedImages[index] = pickedFile; // 선택된 이미지로 업데이트
-        state = state.copyWith(storeImages: updatedImages); // 상태 업데이트
+        List<XFile?> updatedImages = List.from(state.storeImages);
+        updatedImages[index] = pickedFile;
+        state = state.copyWith(storeImages: updatedImages);
       }
     } else {
-      print("이미지 선택이 취소되었습니다."); // 사용자가 이미지를 선택하지 않은 경우
+      print("이미지 선택이 취소되었습니다.");
     }
   }
 
-  /// Firebase Storage에 이미지를 업로드하고 URL을 반환하는 메서드
-  /// [imageFile]: 업로드할 이미지 파일, [folderName]: 저장할 폴더 이름
   Future<String?> uploadImage(XFile? imageFile, String folderName) async {
-    if (imageFile == null) return null; // 이미지가 선택되지 않은 경우 null 반환
+    if (imageFile == null) return null;
     try {
-      print('Uploading image: ${imageFile.path}'); // 업로드 진행 로그 출력
-      String fileName = DateTime.now().millisecondsSinceEpoch.toString(); // 파일 이름을 현재 시간으로 생성
-      Reference storageRef = _storage.ref().child('$folderName/$fileName'); // Firebase Storage 경로 설정
-      UploadTask uploadTask = storageRef.putFile(File(imageFile.path)); // 파일을 업로드
-      TaskSnapshot snapshot = await uploadTask; // 업로드가 완료될 때까지 대기
-      String downloadUrl = await snapshot.ref.getDownloadURL(); // 다운로드 가능한 URL 가져오기
-      print('Upload success: $downloadUrl'); // 업로드 성공 로그
-      return downloadUrl; // 업로드 성공 시 URL 반환
+      print('Uploading image: ${imageFile.path}');
+      String fileName = DateTime.now().millisecondsSinceEpoch.toString();
+      Reference storageRef = _storage.ref().child('$folderName/$fileName');
+      UploadTask uploadTask = storageRef.putFile(File(imageFile.path));
+      TaskSnapshot snapshot = await uploadTask;
+      String downloadUrl = await snapshot.ref.getDownloadURL();
+      print('Upload success: $downloadUrl');
+      return downloadUrl;
     } catch (e) {
-      print('Image upload failed: $e'); // 업로드 실패 로그
-      return null; // 실패 시 null 반환
+      print('Image upload failed: $e');
+      return null;
     }
   }
 
-  /// Firebase Firestore에 데이터 저장 및 업로드된 이미지 URL을 처리하는 메서드
-  /// [ownerEmail]: 현재 사용자의 이메일을 ownerId로 사용
-  Future<void> submitDetails(String ownerEmail) async {
-    state = state.copyWith(isLoading: true, uploadError: null); // 업로드 시작, 상태를 로딩으로 설정
-    List<String?> imageUrls = []; // 업로드된 이미지 URL을 저장할 리스트
+  Future<void> submitDetails() async {
+    final ownerEmail = state.ownerEmail;
+    if (ownerEmail == null) {
+      state = state.copyWith(uploadError: '오류가 발생했습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    state = state.copyWith(isLoading: true, uploadError: null);
+    List<String?> imageUrls = [];
 
     // 각 이미지 업로드 및 URL 저장
     for (int i = 0; i < state.storeImages.length; i++) {
       if (state.storeImages[i] != null) {
-        String? imageUrl = await uploadImage(state.storeImages[i], 'storeImages'); // 이미지 업로드
+        String? imageUrl =
+            await uploadImage(state.storeImages[i], 'storeImages');
         if (imageUrl != null) {
-          imageUrls.add(imageUrl); // 성공적으로 업로드된 경우 URL 추가
+          imageUrls.add(imageUrl);
+        } else {
+          imageUrls.add(null); // 업로드 실패 시 null 추가
         }
+      } else {
+        imageUrls.add(null); // 이미지가 없을 경우 null 추가
       }
     }
 
     // 로고 이미지 업로드
     String? logoUrl = await uploadImage(state.storeLogo, 'storeLogo');
 
-    // Firestore에 저장할 데이터를 PhotoUpload 모델을 사용하여 준비
+    // Firestore에 저장할 데이터를 준비
     PhotoUpload photoUpload = PhotoUpload(
-      pubId: '', // pubId는 Firestore에서 자동 생성
-      ownerId: ownerEmail, // ownerEmail을 ownerId로 사용
-      logoUrl: logoUrl, // 업로드된 로고 URL
-      photoUrls: imageUrls, // 업로드된 이미지 URL 리스트
-      message: state.message, // 사용자가 입력한 메시지
+      ownerId: ownerEmail,
+      logoUrl: logoUrl,
+      photoUrls: imageUrls,
+      message: state.message,
     );
 
     try {
-      // Firestore에 데이터 저장 후, 자동 생성된 pubId를 가져옴
-      DocumentReference docRef = await _firestore.collection('PubInfos').add(photoUpload.toMap());
+      DocumentReference docRef =
+          await _firestore.collection('PubInfos').add(photoUpload.toJson());
 
-      // 생성된 pubId를 Firestore에 업데이트
-      await docRef.update({'pubId': docRef.id}); // 자동 생성된 pubId로 업데이트
-      state = state.copyWith(isLoading: false); // 상태 업데이트, 로딩 종료
-      print('Data saved with pubId: ${docRef.id}'); // 성공적으로 저장된 pubId 출력
+      await docRef.update({'pubId': docRef.id});
+      state = state.copyWith(isLoading: false);
+      print('Data saved with pubId: ${docRef.id}');
     } catch (e) {
-      print('Error occurred while saving to Firestore: $e'); // 저장 중 오류 발생 시 로그 출력
-      state = state.copyWith(isLoading: false, uploadError: 'Upload failed. Please try again.'); // 오류 메시지 상태 업데이트
+      print('Error occurred while saving to Firestore: $e');
+      state = state.copyWith(
+          isLoading: false, uploadError: '업로드에 실패했습니다. 다시 시도해주세요.');
     }
   }
 
-  /// 메시지 업데이트 메서드
-  /// 사용자가 입력한 메시지를 상태에 반영
   void updateMessage(String message) {
-    state = state.copyWith(message: message); // 메시지 상태 업데이트
-    _validateForm(); // 폼 유효성 검사 호출
+    state = state.copyWith(message: message);
   }
 
-  /// 폼 유효성 검사
-  /// 최소한 1개의 이미지, 로고, 그리고 메시지가 입력되었는지 확인
   bool get isFormValid {
-    bool hasAtLeastOneImage = state.storeImages.any((image) => image != null); // 1개 이상의 이미지가 있는지 확인
-    return state.message.isNotEmpty && hasAtLeastOneImage && state.storeLogo != null; // 메시지, 이미지, 로고가 있는지 확인
-  }
-
-  /// 폼 유효성을 체크하여 버튼 활성화 여부 결정
-  void _validateForm() {
-    state = state.copyWith(isLoading: !isFormValid); // 폼이 유효하지 않으면 isLoading을 true로 설정하여 버튼 비활성화
+    bool hasAtLeastOneImage =
+        state.storeImages.any((image) => image != null);
+    return state.message.isNotEmpty &&
+        hasAtLeastOneImage &&
+        state.storeLogo != null;
   }
 }
 
-// PhotoUploadViewModel provider를 정의
 final photoUploadViewModelProvider =
     StateNotifierProvider<PhotoUploadViewModel, PhotoUploadState>(
   (ref) => PhotoUploadViewModel(),


### PR DESCRIPTION
주요 변경사항: 
1. shared_preferences에 알람 설정여부를 저장하는 코드를 추가
2. 회원가입시 가게가 최대로 사용자에게 보낼수 있는 포인트 제한을 100,000으로 기본 설정하여 추가
3. owner user setting tab구현

lib/model/owner_model.dart: pointLimit를 기본 100,000으로 추가 및 freezed로 수정

lib/model/owner_signup_state_model.dart: owner_sign_up_view_model 에서 state를 분활

lib/model/photo_upload_model.dart: freezed로 수정

lib/model/photo_upload_state_model.dart: photo_upload_view_model에서 state 분리

lib/services/preferences_manager.dart: 알림설정여부를 저장및 불러오는 코드 추가

lib/view/sign-up/owner_email_auth_screen.dart: 기능별 위젯분리

lib/view/tab/owner/owner_home_screen.dart: 
settings 탭에 아래 파일 경로 추가
point_limit_screen.dart
privacy_policy_screen.dart
terms_of_service_screen.dart

lib/view/tab/owner/owner_settings_tab.dart: setting tab구현

lib/view/tab/owner/point_limit_screen.dart: 포인트 상한선을 입력하여 firestore owners 컬렉션 pointLimit 필드에 set

lib/view/tab/privacy_policy_screen.dart: 개인정보 이용방침화면

lib/view/tab/terms_of_service_screen.dart: 이용약관화면

lib/view/tab/user/user_home_screen.dart: 
settings 탭에 아래 파일 경로 추가
privacy_policy_screen.dart
terms_of_service_screen.dart

lib/view/tab/user/user_settings_tab.dart: 알림을 설정여부를 preferences_manager에 저장

lib/viewModel/owner_settings_tab_view_model.dart: settings tab과 point_limit_screen의 viewmodel

lib/viewModel/photo_upload_view_model.dart: 기존 state를 photo_upload_state_model.dart로 분리함에 따른 변경 로직은 변경하지 않았습니다.

lib/viewModel/point_management_view_model.dart: updateUserPoints()를 bool에서 string으로 변경(에러 알림을 직접 string으로 전달) 거래 금액이 pointLimit를 초과시 에러 알림

lib/view/tab/owner/point_management_screen.dart: 에러를 반영하도록 수정