### PR TITLE
Owner account

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -167,9 +167,9 @@ class AuthService {
   //사용자 패스워드를 재인증합니다.
   Future<bool> validatePassword(String password) async {
     try {
-      final Email = await PreferencesManager.instance.getEmail();
+      final email = await PreferencesManager.instance.getEmail();
 
-      if (Email == null || Email.isEmpty) {
+      if (email == null || email.isEmpty) {
         throw Exception('사용자의 이메일 정보를 확인할 수 없습니다.');
       }
 
@@ -182,7 +182,7 @@ class AuthService {
 
       // 2. 이메일과 비밀번호로 자격 증명 생성
       final credential = EmailAuthProvider.credential(
-        email: Email,
+        email: email,
         password: password,
       );
 
@@ -190,7 +190,7 @@ class AuthService {
       await currentUser.reauthenticateWithCredential(credential);
 
       // 4. 비밀번호 재설정 이메일 전송
-      await sendPasswordResetEmail(Email);
+      await sendPasswordResetEmail(email);
 
       print('비밀번호 인증 성공'); // 성공 로그
       return true;
@@ -201,9 +201,9 @@ class AuthService {
   }
 
   //현재 사용자 이메일로 비밀번호 재설정 이메일을 보냅니다.
-  Future<void> sendPasswordResetEmail(String Email) async {
+  Future<void> sendPasswordResetEmail(String email) async {
     try {
-      final user = Email; // 현재 상태에서 사용자 데이터를 가져옵니다.
+      final user = email; // 현재 상태에서 사용자 데이터를 가져옵니다.
 
       if (user.isEmpty) {
         throw Exception('사용자의 이메일 정보를 확인할 수 없습니다.');

--- a/lib/view/tab/owner/owner_account_screen.dart
+++ b/lib/view/tab/owner/owner_account_screen.dart
@@ -1,0 +1,283 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../viewModel/owner_account_view_model.dart';
+import '../../../services/auth_service.dart';
+
+class OwnerAccountScreen extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+    // 병합된 상태를 Provider에서 직접 가져오기
+    final combinedState = ref.watch(ownerAccountProvider);
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: combinedState.when(
+          loading: () => Center(child: CircularProgressIndicator()),
+          error: (error, stackTrace) => Center(child: Text('오류 발생: $error')), // 에러 상태
+          data: (data) {
+            final owner = data['owner']; // Owner 데이터
+            final pubInfo = data['pubInfo']; // PubInfo 데이터
+            return Column(
+              children: [
+                _buildProfileSection(owner, pubInfo, screenWidth, screenHeight),
+                SizedBox(height: screenHeight * 0.15), // 프로필 섹션 아래 여백
+                Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.05),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _buildDetailsSection(context, owner, screenWidth, screenHeight),
+                        SizedBox(height: screenHeight * 0.01),
+                        Divider(thickness: screenHeight * 0.001, color: Colors.grey[300]),
+                        SizedBox(height: screenHeight * 0.01),
+                        _buildPasswordChangeSection(context, owner, screenWidth, screenHeight),
+                        Divider(thickness: screenHeight * 0.001, color: Colors.grey[300]),
+                        _buildStorePhotoSettingSection(context, screenWidth, screenHeight),
+                        Divider(thickness: screenHeight * 0.001, color: Colors.grey[300]),
+                      ],
+                    ),
+                  ),
+                ),
+                _buildLogoutButton(context, ref, screenWidth, screenHeight),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  // 프로필 섹션
+  Widget _buildProfileSection(dynamic owner, dynamic pubInfo, double screenWidth, double screenHeight) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Container(
+          width: double.infinity,
+          height: screenHeight * 0.3,
+          color: const Color(0xFFE3E8EF), // 배경색 설정
+        ),
+        Positioned(
+          bottom: -(screenHeight * 0.1),
+          left: (screenWidth - screenHeight * 0.2) / 2,
+          child: Column(
+            children: [
+              CircleAvatar(
+                radius: screenHeight * 0.1,
+                backgroundColor: const Color(0xFF4A6FA5),
+                backgroundImage: pubInfo.logoUrl != null
+                    ? NetworkImage(pubInfo.logoUrl!) // logoUrl에서 이미지 가져오기
+                    : null,
+                child: pubInfo.logoUrl == null
+                    ? Icon(
+                        Icons.store, // 기본 아이콘 변경
+                        size: screenHeight * 0.08,
+                        color: Colors.white,
+                      )
+                    : null,
+              ),
+              SizedBox(height: screenHeight * 0.02),
+              Text(
+                owner.storeName,
+                style: TextStyle(
+                  fontSize: screenWidth * 0.06,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+ // 상세 정보 섹션
+  Widget _buildDetailsSection(BuildContext context, dynamic owner, double screenWidth, double screenHeight) {
+    return Column(
+      children: [
+        GestureDetector(
+          onTap: () {
+            Navigator.pushNamed(context, '/SignupUpdate'); // 매장 선택 화면 이동
+          },
+          child: _buildInfoRow(
+            title: '${owner.storeName ?? '未登録'}@${owner.address ?? ''}', // storeName과 address 결합
+            value: '',
+            isLongText: true,
+            screenWidth: screenWidth,
+            showIcon: true,
+          ),
+        ),
+        _buildInfoRow(
+          title: 'メールアドレス',
+          value: owner.email,
+          isLongText: true,
+          screenWidth: screenWidth,
+          showIcon: false,
+        ),
+      ],
+    );
+  }
+
+  // 정보 행 위젯
+  Widget _buildInfoRow({
+    required String title,
+    required String value,
+    required bool isLongText,
+    required double screenWidth,
+    required bool showIcon,
+  }) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: screenWidth * 0.04,
+            color: const Color.fromARGB(255, 145, 163, 189),
+          ),
+        ),
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: Padding(
+              padding: EdgeInsets.only(right: screenWidth * 0.05),
+              child: isLongText && value.length > 20
+                  ? Text.rich(
+                      TextSpan(
+                        children: [
+                          TextSpan(text: value.substring(0, 18)),
+                          TextSpan(text: '\n${value.substring(18)}'),
+                        ],
+                      ),
+                      style: TextStyle(
+                        fontSize: screenWidth * 0.04,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.right,
+                    )
+                  : Text(
+                      value,
+                      style: TextStyle(
+                        fontSize: screenWidth * 0.04,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+            ),
+          ),
+        ),
+        if (showIcon)
+          Icon(
+            Icons.arrow_forward_ios,
+            size: screenWidth * 0.04,
+            color: Colors.grey,
+          ),
+      ],
+    );
+  }
+
+  // 비밀번호 변경 섹션
+  Widget _buildPasswordChangeSection(BuildContext context, dynamic owner, double screenWidth, double screenHeight) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: () {
+        Navigator.pushNamed(context, '/verifyPassword');
+      },
+      child: Container(
+        padding: EdgeInsets.symmetric(vertical: screenHeight * 0.02),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'パスワード変更',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: screenWidth * 0.04,
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              size: screenWidth * 0.04,
+              color: Colors.grey,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // 店舗写真設定 섹션 추가
+  Widget _buildStorePhotoSettingSection(BuildContext context, double screenWidth, double screenHeight) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: () {
+        Navigator.pushNamed(context, '/photoUpdate'); // 매장 사진 설정 화면 이동
+      },
+      child: Container(
+        padding: EdgeInsets.symmetric(vertical: screenHeight * 0.02),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '店舗写真設定',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: screenWidth * 0.04,
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              size: screenWidth * 0.04,
+              color: Colors.grey,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // 로그아웃 버튼
+  Widget _buildLogoutButton(BuildContext context, WidgetRef ref, double screenWidth, double screenHeight) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: screenWidth * 0.05,
+        vertical: screenHeight * 0.02,
+      ),
+      child: OutlinedButton(
+        onPressed: () async {
+          final authService = AuthService();
+          await authService.logout(context, ref); // 로그아웃 처리
+          Navigator.of(context, rootNavigator: true).pushReplacementNamed('/first'); // 첫 화면으로 이동
+        },
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(
+            color: Colors.black,
+            width: screenWidth * 0.005,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(screenWidth * 0.1),
+          ),
+          padding: EdgeInsets.symmetric(
+            vertical: screenHeight * 0.015,
+          ),
+          minimumSize: Size(screenWidth, screenHeight * 0.05),
+        ),
+        child: Text(
+          'ログアウト',
+          style: TextStyle(
+            fontSize: screenWidth * 0.04,
+            fontWeight: FontWeight.bold,
+            color: Colors.black,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/tab/owner/owner_home_screen.dart
+++ b/lib/view/tab/owner/owner_home_screen.dart
@@ -11,6 +11,10 @@ import '../event_home.dart';
 import 'point_limit_screen.dart';
 import '../privacy_policy_screen.dart';
 import '../terms_of_service_screen.dart';
+import 'owner_account_screen.dart';
+import '../verify_password_screen.dart';
+import 'photo_update_screen.dart';
+import 'owner_signup_update_screen.dart';
 
 class OwnerHomeScreen extends ConsumerWidget {
   @override
@@ -23,7 +27,7 @@ class OwnerHomeScreen extends ConsumerWidget {
       EventPageView(),
       OwnerTransactionHistoryScreen(),
       ScanTabNavigator(), // QR 코드 스캔 및 포인트 관리 페이지
-      AccountTab(),
+      OwnerAccountTab(),
       OwnerSettings(),
     ];
 
@@ -127,21 +131,32 @@ class OwnerSettings extends StatelessWidget {
   }
 }
 
-// 각 탭에 해당하는 더미 화면들
-class HomeTab extends StatelessWidget {
+// QR 코드 스캔 및 포인트 관리 페이지를 위한 Navigator
+class OwnerAccountTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text('ホーム'),
-    );
-  }
-}
-
-class AccountTab extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Text('アカウント'),
+    return Navigator(
+      onGenerateRoute: (settings) {
+        switch (settings.name) {
+          case '/SignupUpdate': // VerifyPasswordScreen으로 이동하는 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => OwnerSignUpUpdateScreen(),
+            );
+            
+          case '/verifyPassword': // VerifyPasswordScreen으로 이동하는 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => VerifyPasswordScreen(),
+            );
+          case '/photoUpdate': // VerifyPasswordScreen으로 이동하는 경로 추가
+            return MaterialPageRoute(
+              builder: (context) => PhotoUpdateScreen(),
+            );
+          default:
+            return MaterialPageRoute(
+              builder: (context) => OwnerAccountScreen(),
+            );
+        }
+      },
     );
   }
 }

--- a/lib/view/tab/owner/owner_signup_update_screen.dart
+++ b/lib/view/tab/owner/owner_signup_update_screen.dart
@@ -152,12 +152,6 @@ class StoreNameField extends ConsumerWidget {
       hint: '店舗名を入力してください',
       screenWidth: screenWidth,
       onChanged: signUpViewModel.updateStoreName,
-      validator: (value) {
-        if (value == null || value.isEmpty) {
-          return '店舗名を入力してください';
-        }
-        return null;
-      },
     );
   }
 }
@@ -180,12 +174,6 @@ class AddressFields extends ConsumerWidget {
             hint: '郵便番号を入力してください',
             screenWidth: screenWidth,
             onChanged: signUpViewModel.updateZipCode,
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return '郵便番号を入力してください';
-              }
-              return null;
-            },
           ),
         ),
         SizedBox(width: screenWidth * 0.02), // Spacer between Zip Code and Prefecture
@@ -195,12 +183,6 @@ class AddressFields extends ConsumerWidget {
             hint: '都道府県を入力してください',
             screenWidth: screenWidth,
             onChanged: signUpViewModel.updateState,
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return '都道府県を入力してください';
-              }
-              return null;
-            },
           ),
         ),
       ],
@@ -223,12 +205,6 @@ class CityField extends ConsumerWidget {
       hint: '市区町村を入力してください',
       screenWidth: screenWidth,
       onChanged: signUpViewModel.updateCity,
-      validator: (value) {
-        if (value == null || value.isEmpty) {
-          return '市区町村を入力してください';
-        }
-        return null;
-      },
     );
   }
 }
@@ -248,12 +224,6 @@ class AddressField extends ConsumerWidget {
       hint: '住所を入力してください',
       screenWidth: screenWidth,
       onChanged: signUpViewModel.updateAddress,
-      validator: (value) {
-        if (value == null || value.isEmpty) {
-          return '住所を入力してください';
-        }
-        return null;
-      },
     );
   }
 }
@@ -346,7 +316,6 @@ class CustomTextField extends StatelessWidget {
   final String hint;
   final double screenWidth;
   final Function(String) onChanged;
-  final String? Function(String?)? validator;
   final bool isOptional;
 
   const CustomTextField({
@@ -354,7 +323,6 @@ class CustomTextField extends StatelessWidget {
     required this.hint,
     required this.screenWidth,
     required this.onChanged,
-    this.validator,
     this.isOptional = false,
   });
 
@@ -373,13 +341,6 @@ class CustomTextField extends StatelessWidget {
             ),
             hintText: hint,
           ),
-          validator: validator ??
-              (value) {
-                if (!isOptional && (value == null || value.isEmpty)) {
-                  return '$labelを入力してください';
-                }
-                return null;
-              },
           onChanged: (value) {
             onChanged(value);
           },

--- a/lib/view/tab/owner/owner_signup_update_screen.dart
+++ b/lib/view/tab/owner/owner_signup_update_screen.dart
@@ -1,0 +1,392 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../viewModel/owner_sign_up_view_model.dart';
+import '../../../model/owner_signup_state_model.dart';
+
+/// Main Sign-Up Screen
+class OwnerSignUpUpdateScreen extends ConsumerStatefulWidget {
+  @override
+  _OwnerSignUpScreenState createState() => _OwnerSignUpScreenState();
+}
+
+class _OwnerSignUpScreenState extends ConsumerState<OwnerSignUpUpdateScreen> {
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Watch the sign-up state to rebuild UI on changes
+    final signUpState = ref.watch(ownerSignUpViewModelProvider);
+    // Read the ViewModel to perform state changes
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
+    // Navigate to PhotoUploadScreen on successful sign-up
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (signUpState.signUpSuccess) {
+        print('Navigating to PhotoUploadScreen'); // Debug log
+        Navigator.pop(context);
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('アカウント作成が完了しました。写真をアップロードしてください。')),
+        );
+        signUpViewModel.resetSignUpSuccess();
+      }
+
+      if (signUpState.signUpError != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(signUpState.signUpError!)),
+        );
+        signUpViewModel.resetSignUpError();
+      }
+    });
+
+    // Calculate screen size using MediaQuery
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+    return Scaffold(
+      appBar: CustomAppBar(),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(screenWidth * 0.04), // Set padding for the entire screen
+        child: Form(
+          key: _formKey, // Manage form state
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              FormTitle(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              StoreNameField(screenWidth: screenWidth, signUpViewModel: signUpViewModel),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              AddressFields(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              CityField(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              AddressField(screenWidth: screenWidth),
+              SizedBox(height: screenHeight * 0.02), // Spacer
+
+              BuildingField(screenWidth: screenWidth, signUpViewModel: signUpViewModel),
+              SizedBox(height: screenHeight * 0.1), // Extra space above the button
+
+              SubmitButton(
+                onPressed: () async {
+                  if (_formKey.currentState?.validate() ?? false) {
+                    await signUpViewModel.updateOwnerInfo();
+                    Navigator.pop(context);
+                  }
+                },
+                screenWidth: screenWidth,
+                screenHeight: screenHeight,
+              ),
+              SizedBox(height: screenHeight * 0.02), // Bottom spacer
+
+              TermsText(screenWidth: screenWidth),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Custom AppBar Widget
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      leading: IconButton(
+        icon: Icon(Icons.arrow_back, color: Colors.grey),
+        onPressed: () => Navigator.pop(context), // Back button
+      ),
+      backgroundColor: Colors.transparent, // Transparent AppBar
+      elevation: 0, // Remove shadow
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(kToolbarHeight);
+}
+
+/// Form Title Widget
+class FormTitle extends StatelessWidget {
+  final double screenWidth;
+
+  const FormTitle({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        '会員登録', // Title
+        style: TextStyle(
+          fontSize: screenWidth * 0.06, // Relative font size
+          fontWeight: FontWeight.bold, // Bold font
+        ),
+      ),
+    );
+  }
+}
+
+/// Store Name Field Widget
+class StoreNameField extends ConsumerWidget {
+  final double screenWidth;
+  final OwnerSignUpViewModel signUpViewModel;
+
+  const StoreNameField({
+    required this.screenWidth,
+    required this.signUpViewModel,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CustomTextField(
+      label: '店舗名',
+      hint: '店舗名を入力してください',
+      screenWidth: screenWidth,
+      onChanged: signUpViewModel.updateStoreName,
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return '店舗名を入力してください';
+        }
+        return null;
+      },
+    );
+  }
+}
+
+/// Address Fields Widget (Zip Code and Prefecture)
+class AddressFields extends ConsumerWidget {
+  final double screenWidth;
+
+  const AddressFields({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
+    return Row(
+      children: [
+        Expanded(
+          child: CustomTextField(
+            label: '郵便番号',
+            hint: '郵便番号を入力してください',
+            screenWidth: screenWidth,
+            onChanged: signUpViewModel.updateZipCode,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return '郵便番号を入力してください';
+              }
+              return null;
+            },
+          ),
+        ),
+        SizedBox(width: screenWidth * 0.02), // Spacer between Zip Code and Prefecture
+        Expanded(
+          child: CustomTextField(
+            label: '都道府県',
+            hint: '都道府県を入力してください',
+            screenWidth: screenWidth,
+            onChanged: signUpViewModel.updateState,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return '都道府県を入力してください';
+              }
+              return null;
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// City Field Widget
+class CityField extends ConsumerWidget {
+  final double screenWidth;
+
+  const CityField({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
+    return CustomTextField(
+      label: '市区町村',
+      hint: '市区町村を入力してください',
+      screenWidth: screenWidth,
+      onChanged: signUpViewModel.updateCity,
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return '市区町村を入力してください';
+        }
+        return null;
+      },
+    );
+  }
+}
+
+/// Address Field Widget
+class AddressField extends ConsumerWidget {
+  final double screenWidth;
+
+  const AddressField({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signUpViewModel = ref.read(ownerSignUpViewModelProvider.notifier);
+
+    return CustomTextField(
+      label: '住所',
+      hint: '住所を入力してください',
+      screenWidth: screenWidth,
+      onChanged: signUpViewModel.updateAddress,
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return '住所を入力してください';
+        }
+        return null;
+      },
+    );
+  }
+}
+
+/// Building Field Widget (Optional)
+class BuildingField extends StatelessWidget {
+  final double screenWidth;
+  final OwnerSignUpViewModel signUpViewModel;
+
+  const BuildingField({
+    required this.screenWidth,
+    required this.signUpViewModel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomTextField(
+      label: '建物名、部屋番号など(任意)',
+      hint: '建物名、部屋番号などを入力してください',
+      screenWidth: screenWidth,
+      onChanged: signUpViewModel.updateBuilding,
+      isOptional: true, // Mark as optional
+    );
+  }
+}
+
+/// Submit Button Widget
+class SubmitButton extends StatelessWidget {
+  final VoidCallback onPressed;
+  final double screenWidth;
+  final double screenHeight;
+
+  const SubmitButton({
+    required this.onPressed,
+    required this.screenWidth,
+    required this.screenHeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: onPressed, 
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Color(0xFF1D2538),
+          padding: EdgeInsets.symmetric(
+            horizontal: screenWidth * 0.3, 
+            vertical: screenHeight * 0.01, 
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(50), 
+          ),
+        ),
+        child: Text(
+          'アカウント作成', // Button text
+          style: TextStyle(
+            fontSize: screenWidth * 0.045, // Font size
+            color: Colors.white, // Text color
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Terms and Conditions Text Widget
+class TermsText extends StatelessWidget {
+  final double screenWidth;
+
+  const TermsText({required this.screenWidth});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        'アカウント作成することでサービス利用規約およびプライバシーポリシーに同意したことになります。必ず御読みください。',
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: screenWidth * 0.03, // Text size
+          color: Colors.black,
+        ),
+      ),
+    );
+  }
+}
+
+/// Custom Text Field Widget
+class CustomTextField extends StatelessWidget {
+  final String label;
+  final String hint;
+  final double screenWidth;
+  final Function(String) onChanged;
+  final String? Function(String?)? validator;
+  final bool isOptional;
+
+  const CustomTextField({
+    required this.label,
+    required this.hint,
+    required this.screenWidth,
+    required this.onChanged,
+    this.validator,
+    this.isOptional = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: TextStyle(fontSize: screenWidth * 0.05)),
+        SizedBox(height: 10),
+        TextFormField(
+          decoration: InputDecoration(
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(15.0),
+              borderSide: BorderSide(color: Colors.grey),
+            ),
+            hintText: hint,
+          ),
+          validator: validator ??
+              (value) {
+                if (!isOptional && (value == null || value.isEmpty)) {
+                  return '$labelを入力してください';
+                }
+                return null;
+              },
+          onChanged: (value) {
+            onChanged(value);
+          },
+          autocorrect: false,
+          enableSuggestions: false,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/tab/owner/photo_update_screen.dart
+++ b/lib/view/tab/owner/photo_update_screen.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../viewModel/photo_upload_view_model.dart';
+import 'dart:io';
+import '../../../model/photo_upload_state_model.dart';
+
+class PhotoUpdateScreen extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(photoUploadViewModelProvider);
+    final viewModel = ref.read(photoUploadViewModelProvider.notifier);
+    final screenSize = MediaQuery.of(context).size;
+    final screenWidth = screenSize.width;
+    final screenHeight = screenSize.height;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: Colors.grey),
+          onPressed: () => Navigator.pop(context),
+        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(screenWidth * 0.04),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Text(
+                '店舗詳細情報',
+                style: TextStyle(
+                  fontSize: screenWidth * 0.06,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            SizedBox(height: screenHeight * 0.02),
+            _buildSectionTitle('店舗イメージ登録', screenWidth),
+            _buildImageUploadRow(screenWidth, screenHeight, viewModel, state),
+            SizedBox(height: screenHeight * 0.02),
+            _buildSectionTitle('店舗ロゴ登録', screenWidth),
+            _buildLogoUpload(screenWidth, screenHeight, viewModel, state),
+            SizedBox(height: screenHeight * 0.02),
+            _buildSectionTitle('店舗からのメッセージ', screenWidth),
+            _buildMessageField(screenWidth, viewModel),
+            SizedBox(height: screenHeight * 0.04),
+            Center(
+              child: ElevatedButton(
+                onPressed: state.isLoading || !viewModel.isFormValid
+                    ? null
+                    : () async {
+                        // 기존 이미지를 삭제하고 업데이트
+                        await viewModel.updateStorePhotos();
+
+                        Navigator.pop(context);
+                      },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: viewModel.isFormValid
+                      ? Color(0xFF1D2538)
+                      : Colors.grey,
+                  padding: EdgeInsets.symmetric(
+                    horizontal: screenWidth * 0.3,
+                    vertical: screenHeight * 0.015,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(50),
+                  ),
+                ),
+                child: Text(
+                  '詳細情報登録',
+                  style: TextStyle(
+                    fontSize: screenWidth * 0.045,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(String title, double screenWidth) {
+    return Text(
+      title,
+      style: TextStyle(
+        fontSize: screenWidth * 0.045,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+
+  Widget _buildImageUploadRow(double screenWidth, double screenHeight,
+      PhotoUploadViewModel viewModel, PhotoUploadState state) {
+    return Container(
+      width: screenWidth * 0.9,
+      height: screenHeight * 0.16,
+      padding: EdgeInsets.all(screenWidth * 0.02),
+      decoration: BoxDecoration(
+        color: Colors.grey[200],
+        borderRadius: BorderRadius.circular(screenWidth * 0.02),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: List.generate(3, (index) {
+          final imageFile = state.storeImages[index];
+
+          return GestureDetector(
+            onTap: () => viewModel.pickImage(index),
+            child: Stack(
+              children: [
+                Container(
+                  width: screenWidth * 0.25,
+                  height: screenWidth * 0.25,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    border: Border.all(color: Colors.transparent),
+                  ),
+                  child: Center(
+                    child: imageFile != null
+                        ? Image.file(
+                            File(imageFile.path),
+                            fit: BoxFit.cover,
+                            width: screenWidth * 0.25,
+                            height: screenWidth * 0.25,
+                          )
+                        : index == 0
+                            ? Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(Icons.camera_alt,
+                                      size: screenWidth * 0.08,
+                                      color: Colors.grey),
+                                  Text("必須",
+                                      style: TextStyle(
+                                          color: Colors.blue,
+                                          fontSize: screenWidth * 0.035)),
+                                ],
+                              )
+                            : null,
+                  ),
+                ),
+                Positioned(
+                  top: screenHeight * 0.005,
+                  left: screenWidth * 0.01,
+                  child: Container(
+                    padding: EdgeInsets.symmetric(
+                        horizontal: screenWidth * 0.015,
+                        vertical: screenHeight * 0.005),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[600],
+                      borderRadius: BorderRadius.circular(screenWidth * 0.01),
+                    ),
+                    child: Text(
+                      '${index + 1}',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: screenWidth * 0.03,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  Widget _buildLogoUpload(double screenWidth, double screenHeight,
+      PhotoUploadViewModel viewModel, PhotoUploadState state) {
+    final logoFile = state.storeLogo;
+
+    return Center(
+      child: GestureDetector(
+        onTap: () async {
+          await viewModel.pickImage(0, isLogo: true);
+        },
+        child: Container(
+          width: screenWidth * 0.5,
+          height: screenWidth * 0.5,
+          padding: EdgeInsets.all(screenWidth * 0.04),
+          decoration: BoxDecoration(
+            color: Colors.grey[200],
+            borderRadius: BorderRadius.circular(screenWidth * 0.02),
+          ),
+          child: Container(
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.zero,
+            ),
+            child: logoFile != null
+                ? ClipRRect(
+                    borderRadius: BorderRadius.circular(screenWidth * 0.02),
+                    child: Image.file(
+                      File(logoFile.path),
+                      fit: BoxFit.cover,
+                      width: screenWidth * 0.5,
+                      height: screenWidth * 0.5,
+                    ),
+                  )
+                : Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.camera_alt,
+                            size: screenWidth * 0.1, color: Colors.grey),
+                        Text("必須",
+                            style: TextStyle(
+                                color: Colors.blue,
+                                fontSize: screenWidth * 0.035)),
+                      ],
+                    ),
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMessageField(
+      double screenWidth, PhotoUploadViewModel viewModel) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(screenWidth * 0.025),
+        border:
+            Border.all(color: Colors.grey[300]!, width: screenWidth * 0.01),
+      ),
+      padding: EdgeInsets.symmetric(
+          horizontal: screenWidth * 0.03, vertical: screenWidth * 0.02),
+      child: TextField(
+        onChanged: (value) {
+          viewModel.updateMessage(value);
+        },
+        decoration: InputDecoration(
+          border: InputBorder.none,
+          hintText: '店舗からのメッセージを入力してください',
+          hintStyle:
+              TextStyle(color: Colors.grey[500], fontSize: screenWidth * 0.04),
+        ),
+        maxLines: 3,
+      ),
+    );
+  }
+}

--- a/lib/view/tab/owner/point_management_screen.dart
+++ b/lib/view/tab/owner/point_management_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart'; // For number formatting
-import 'package:qrr_project/viewModel/qrcode_scan_view_model.dart';
-import '../../../viewModel/point_management_view_model.dart'; // 올바른 ViewModel 경로 사용
+import 'package:intl/intl.dart';
+import '../../../viewModel/point_management_view_model.dart';
+import '../../../viewModel/qrcode_scan_view_model.dart';
 
 class PointManagementScreen extends ConsumerStatefulWidget {
   @override
@@ -13,7 +13,6 @@ class _PointManagementScreenState extends ConsumerState<PointManagementScreen> {
   @override
   void initState() {
     super.initState();
-    // 초기 상태에서 fetchUserData 호출하여 사용자의 이름과 정보 가져오기
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(transactionProvider.notifier).fetchUserData(ref);
     });
@@ -22,13 +21,8 @@ class _PointManagementScreenState extends ConsumerState<PointManagementScreen> {
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
-    final screenWidth = screenSize.width;
-    final screenHeight = screenSize.height;
-    final double reducedHeight = screenHeight * 0.05;
-
     final transaction = ref.watch(transactionProvider);
-    final profilePicUrl = transaction?.profilePicUrl;
-    final numberFormat = NumberFormat("#,###");
+
     return PopScope<Object?>(
       canPop: false, // 뒤로 가기 제스처 및 버튼을 막음
       onPopInvokedWithResult: (bool didPop, Object? result) {
@@ -36,290 +30,40 @@ class _PointManagementScreenState extends ConsumerState<PointManagementScreen> {
       },
       child: Scaffold(
         backgroundColor: Colors.white,
-        body: SingleChildScrollView( // 화면 스크롤 가능하도록 설정
+        body: SingleChildScrollView(
           child: Padding(
-            padding: EdgeInsets.all(screenWidth * 0.02),
+            padding: EdgeInsets.all(screenSize.width * 0.02),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Padding(
-                  padding: EdgeInsets.only(top: screenHeight * 0.05),
-                  child: Text(
-                    'ポイント管理',
-                    style: TextStyle(
-                      color: Colors.black,
-                      fontSize: screenWidth * 0.07,
-                      fontWeight: FontWeight.bold,
-                    ),
+                SizedBox(height: screenSize.height * 0.05),
+                Text(
+                  'ポイント管理',
+                  style: TextStyle(
+                    fontSize: screenSize.width * 0.07,
+                    fontWeight: FontWeight.bold,
                   ),
                 ),
-                SizedBox(height: screenHeight * 0.015),
-                Container(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: screenWidth * 0.02,
-                    vertical: reducedHeight * 0.25,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    borderRadius: BorderRadius.circular(screenWidth * 0.02),
-                    border: Border.all(color: Colors.grey.shade300),
-                  ),
-                  child: Row(
-                    children: [
-                      CircleAvatar(
-                        radius: screenWidth * 0.05,
-                        backgroundColor: Colors.grey,
-                        backgroundImage: (profilePicUrl != null && profilePicUrl.isNotEmpty)
-                            ? NetworkImage(profilePicUrl)
-                            : null,
-                        child: (profilePicUrl == null || profilePicUrl.isEmpty)
-                            ? Icon(Icons.person, size: screenWidth * 0.06, color: Colors.white)
-                            : null,
-                      ),
-                      SizedBox(width: screenWidth * 0.03),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            transaction?.name ?? 'ユーザー名を取得中...',
-                            style: TextStyle(
-                              fontSize: screenWidth * 0.04,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          Text(
-                            transaction?.uid ?? '0000-0000-0000',
-                            style: TextStyle(fontSize: screenWidth * 0.03),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-                SizedBox(height: screenHeight * 0.015),
-                Container(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: screenWidth * 0.03,
-                    vertical: reducedHeight * 0.25,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    borderRadius: BorderRadius.circular(screenWidth * 0.02),
-                    border: Border.all(color: Colors.grey.shade300),
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'ご利用可能なポイント',
-                        style: TextStyle(
-                          fontSize: screenWidth * 0.04,
-                        ),
-                      ),
-                      SizedBox(height: screenHeight * 0.002),
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: Text(
-                          '${numberFormat.format(transaction?.point ?? 0)} pt',
-                          style: TextStyle(
-                            fontSize: screenWidth * 0.04,
-                            color: Colors.grey,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                SizedBox(height: screenHeight * 0.015),
-                Container(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: screenWidth * 0.025,
-                    vertical: reducedHeight * 0.25,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    borderRadius: BorderRadius.circular(screenWidth * 0.02),
-                    border: Border.all(color: Colors.grey.shade300),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      Expanded(
-                        child: ActionButton(
-                          text: 'チャージ',
-                          isSelected: transaction?.type == 'チャージ',
-                          onPressed: () {
-                            ref.read(transactionProvider.notifier).updateTransactionType('チャージ');
-                          },
-                        ),
-                      ),
-                      SizedBox(width: screenWidth * 0.02),
-                      Expanded(
-                        child: ActionButton(
-                          text: 'チップ交換',
-                          isSelected: transaction?.type == 'チップ交換',
-                          onPressed: () {
-                            ref.read(transactionProvider.notifier).updateTransactionType('チップ交換');
-                          },
-                        ),
-                      ),
-                      SizedBox(width: screenWidth * 0.02),
-                      Expanded(
-                        child: ActionButton(
-                          text: 'お支払い',
-                          isSelected: transaction?.type == 'お支払い',
-                          onPressed: () {
-                            ref.read(transactionProvider.notifier).updateTransactionType('お支払い');
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                SizedBox(height: screenHeight * 0.01),
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.06),
-                  child: Divider(
-                    thickness: 1,
-                    color: Colors.grey.shade300,
-                  ),
-                ),
-                SizedBox(height: screenHeight * 0.003),
+                SizedBox(height: screenSize.height * 0.02),
+                UserProfileSection(transaction: transaction),
+                SizedBox(height: screenSize.height * 0.015),
+                PointsInfoSection(transaction: transaction),
+                SizedBox(height: screenSize.height * 0.015),
+                TransactionTypeSelector(),
+                SizedBox(height: screenSize.height * 0.015),
                 Align(
                   alignment: Alignment.centerRight,
                   child: Text(
-                    '${numberFormat.format(transaction?.amount ?? 0)} pt',
+                    '${NumberFormat("#,###").format(transaction?.amount ?? 0)} pt',
                     style: TextStyle(
-                      fontSize: screenWidth * 0.08,
+                      fontSize: screenSize.width * 0.08,
                       fontWeight: FontWeight.bold,
                     ),
                   ),
                 ),
-                Container(
-                  height: screenHeight * 0.35,
-                  child: GridView.count(
-                    crossAxisCount: 3,
-                    childAspectRatio: 2,
-                    mainAxisSpacing: screenHeight * 0.002,
-                    crossAxisSpacing: screenWidth * 0.01,
-                    physics: NeverScrollableScrollPhysics(),
-                    children: List.generate(12, (index) {
-                      String displayText;
-                      if (index == 9) {
-                        displayText = 'C';
-                      } else if (index == 11) {
-                        return IconButton(
-                          icon: Icon(Icons.backspace, size: screenWidth * 0.07),
-                          onPressed: () {
-                            String currentAmount = (transaction?.amount ?? 0).toString();
-                            if (currentAmount.isNotEmpty && currentAmount != '0') {
-                              String newAmount = currentAmount.substring(0, currentAmount.length - 1);
-                              ref.read(transactionProvider.notifier).updateAmount(int.parse(newAmount.isEmpty ? '0' : newAmount));
-                            }
-                          },
-                        );
-                      } else {
-                        displayText = index == 10 ? '0' : '${index + 1}';
-                      }
-
-                      return GestureDetector(
-                        onTap: () {
-                          if (displayText == 'C') {
-                            ref.read(transactionProvider.notifier).updateAmount(0);
-                          } else {
-                            String currentAmount = (transaction?.amount ?? 0).toString();
-                            if (currentAmount == '0') {
-                              currentAmount = '';
-                            }
-                            if (currentAmount.length < 9) {
-                              String newAmountStr = currentAmount + displayText;
-                              ref.read(transactionProvider.notifier).updateAmount(int.parse(newAmountStr));
-                            }
-                          }
-                        },
-                        child: Container(
-                          margin: EdgeInsets.all(screenWidth * 0.01),
-                          decoration: BoxDecoration(
-                            color: Colors.grey.shade200,
-                            borderRadius: BorderRadius.circular(screenWidth * 0.02),
-                          ),
-                          child: Center(
-                            child: Text(
-                              displayText,
-                              style: TextStyle(fontSize: screenWidth * 0.05, color: Colors.black),
-                            ),
-                          ),
-                        ),
-                      );
-                    }),
-                  ),
-                ),
-                SizedBox(height: screenHeight * 0.02),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  children: [
-                    Expanded(
-                      child: GestureDetector(
-                        onTap: () async {
-                          final errorMessage = await ref.read(transactionProvider.notifier).updateUserPoints(ref);
-                          if (errorMessage == null) {
-                            Navigator.pushNamed(context, '/pointManagementConfirm');
-                          } else {
-                            // 포인트 부족 또는 오류 시 SnackBar 표시
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text(errorMessage)),
-                            );
-                          }
-                        },
-                        child: Container(
-                          padding: EdgeInsets.symmetric(vertical: screenHeight * 0.01),
-                          decoration: BoxDecoration(
-                            color: Color(0xFF1D2538),
-                            borderRadius: BorderRadius.circular(screenWidth * 0.07),
-                          ),
-                          child: Center(
-                            child: Text(
-                              '送る',
-                              style: TextStyle(
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold,
-                                fontSize: screenWidth * 0.045,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    SizedBox(width: screenWidth * 0.05),
-                    Expanded(
-                      child: GestureDetector(
-                        onTap: () {
-                          ref.read(transactionProvider.notifier).clearTransactionState();
-                          Navigator.pop(context);
-                          ref.read(qrViewModelProvider.notifier).resumeCamera();
-                        },
-                        child: Container(
-                          padding: EdgeInsets.symmetric(vertical: screenHeight * 0.01),
-                          decoration: BoxDecoration(
-                            color: Colors.white,
-                            borderRadius: BorderRadius.circular(screenWidth * 0.07),
-                            border: Border.all(color: Color(0xFF1D2538), width: 2),
-                          ),
-                          child: Center(
-                            child: Text(
-                              '受け取る',
-                              style: TextStyle(
-                                color: Color(0xFF1D2538),
-                                fontWeight: FontWeight.bold,
-                                fontSize: screenWidth * 0.045,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+                NumberPad(),
+                SizedBox(height: screenSize.height * 0.02),
+                TransactionActions(),
               ],
             ),
           ),
@@ -328,6 +72,284 @@ class _PointManagementScreenState extends ConsumerState<PointManagementScreen> {
     );
   }
 }
+
+class UserProfileSection extends StatelessWidget {
+  final dynamic transaction;
+
+  const UserProfileSection({required this.transaction});
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final profilePicUrl = transaction?.profilePicUrl;
+
+    return Container(
+      padding: EdgeInsets.all(screenWidth * 0.02),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(screenWidth * 0.02),
+        border: Border.all(color: Colors.grey.shade300),
+      ),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: screenWidth * 0.05,
+            backgroundColor: Colors.grey,
+            backgroundImage: (profilePicUrl != null && profilePicUrl.isNotEmpty)
+                ? NetworkImage(profilePicUrl)
+                : null,
+            child: profilePicUrl == null
+                ? Icon(Icons.person, color: Colors.white, size: screenWidth * 0.06)
+                : null,
+          ),
+          SizedBox(width: screenWidth * 0.03),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                transaction?.name ?? 'ユーザー名を取得中...',
+                style: TextStyle(fontSize: screenWidth * 0.04, fontWeight: FontWeight.bold),
+              ),
+              Text(
+                transaction?.uid ?? '0000-0000-0000',
+                style: TextStyle(fontSize: screenWidth * 0.03),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class PointsInfoSection extends StatelessWidget {
+  final dynamic transaction;
+
+  const PointsInfoSection({required this.transaction});
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    return Container(
+      padding: EdgeInsets.all(screenWidth * 0.03),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(screenWidth * 0.02),
+        border: Border.all(color: Colors.grey.shade300),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('ご利用可能なポイント', style: TextStyle(fontSize: screenWidth * 0.04)),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Text(
+              '${NumberFormat("#,###").format(transaction?.point ?? 0)} pt',
+              style: TextStyle(fontSize: screenWidth * 0.04, color: Colors.grey),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class TransactionTypeSelector extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final transaction = ref.watch(transactionProvider);
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.025, vertical: screenWidth * 0.03),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(screenWidth * 0.02),
+        border: Border.all(color: Colors.grey.shade300),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          Expanded(
+            child: ActionButton(
+              text: 'チャージ',
+              isSelected: transaction?.type == 'チャージ',
+              onPressed: () {
+                ref.read(transactionProvider.notifier).updateTransactionType('チャージ');
+              },
+            ),
+          ),
+          SizedBox(width: screenWidth * 0.02),
+          Expanded(
+            child: ActionButton(
+              text: 'チップ交換',
+              isSelected: transaction?.type == 'チップ交換',
+              onPressed: () {
+                ref.read(transactionProvider.notifier).updateTransactionType('チップ交換');
+              },
+            ),
+          ),
+          SizedBox(width: screenWidth * 0.02),
+          Expanded(
+            child: ActionButton(
+              text: 'お支払い',
+              isSelected: transaction?.type == 'お支払い',
+              onPressed: () {
+                ref.read(transactionProvider.notifier).updateTransactionType('お支払い');
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class NumberPad extends ConsumerWidget {
+  const NumberPad({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final transaction = ref.watch(transactionProvider);
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    return GridView.count(
+      crossAxisCount: 3,
+      childAspectRatio: 2,
+      mainAxisSpacing: screenHeight * 0.002,
+      crossAxisSpacing: screenWidth * 0.01,
+      physics: const NeverScrollableScrollPhysics(),
+      shrinkWrap: true,
+      children: List.generate(12, (index) {
+        String displayText;
+        if (index == 9) {
+          displayText = 'C';
+        } else if (index == 11) {
+          return IconButton(
+            icon: Icon(Icons.backspace, size: screenWidth * 0.07),
+            onPressed: () {
+              String currentAmount = (transaction?.amount ?? 0).toString();
+              if (currentAmount.isNotEmpty && currentAmount != '0') {
+                String newAmount = currentAmount.substring(0, currentAmount.length - 1);
+                ref.read(transactionProvider.notifier).updateAmount(int.parse(newAmount.isEmpty ? '0' : newAmount));
+              }
+            },
+          );
+        } else {
+          displayText = index == 10 ? '0' : '${index + 1}';
+        }
+
+        return GestureDetector(
+          onTap: () {
+            if (displayText == 'C') {
+              ref.read(transactionProvider.notifier).updateAmount(0);
+            } else {
+              String currentAmount = (transaction?.amount ?? 0).toString();
+              if (currentAmount == '0') {
+                currentAmount = '';
+              }
+              if (currentAmount.length < 9) {
+                String newAmountStr = currentAmount + displayText;
+                ref.read(transactionProvider.notifier).updateAmount(int.parse(newAmountStr));
+              }
+            }
+          },
+          child: Container(
+            margin: EdgeInsets.all(screenWidth * 0.01),
+            decoration: BoxDecoration(
+              color: Colors.grey.shade200,
+              borderRadius: BorderRadius.circular(screenWidth * 0.02),
+            ),
+            child: Center(
+              child: Text(
+                displayText,
+                style: TextStyle(fontSize: screenWidth * 0.05, color: Colors.black),
+              ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class TransactionActions extends ConsumerWidget {
+  const TransactionActions({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: [
+        Expanded(
+          child: GestureDetector(
+            onTap: () async {
+              final errorMessage = await ref.read(transactionProvider.notifier).updateUserPoints(ref);
+              if (errorMessage == null) {
+                Navigator.pushNamed(context, '/pointManagementConfirm');
+              } else {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(errorMessage)),
+                );
+              }
+            },
+            child: Container(
+              padding: EdgeInsets.symmetric(vertical: screenHeight * 0.012),
+              decoration: BoxDecoration(
+                color: Color(0xFF1D2538),
+                borderRadius: BorderRadius.circular(screenWidth * 0.07),
+              ),
+              child: Center(
+                child: Text(
+                  '送る',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: screenWidth * 0.045,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        SizedBox(width: screenWidth * 0.05),
+        Expanded(
+          child: GestureDetector(
+            onTap: () {
+              ref.read(transactionProvider.notifier).clearTransactionState();
+              Navigator.pop(context);
+              ref.read(qrViewModelProvider.notifier).resumeCamera();
+            },
+            child: Container(
+              padding: EdgeInsets.symmetric(vertical: screenHeight * 0.01),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(screenWidth * 0.07),
+                border: Border.all(color: Color(0xFF1D2538), width: 2),
+              ),
+              child: Center(
+                child: Text(
+                  '受け取る',
+                  style: TextStyle(
+                    color: Color(0xFF1D2538),
+                    fontWeight: FontWeight.bold,
+                    fontSize: screenWidth * 0.045,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 
 class ActionButton extends StatelessWidget {
   final String text;

--- a/lib/view/tab/user/update_pubid_screen.dart
+++ b/lib/view/tab/user/update_pubid_screen.dart
@@ -28,19 +28,33 @@ class _UpdatePubIdScreenState extends ConsumerState<UpdatePubIdScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          'ご利用店舗選択',
-          style: TextStyle(fontSize: screenWidth * 0.045), // 상대 크기 설정
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context), // 뒤로 가기 버튼
         ),
-        centerTitle: true,
+        title: SizedBox.shrink(),  // AppBar에서 title 제거
+        backgroundColor: Colors.transparent,  // 배경을 투명으로 설정
+        elevation: 0,  // 그림자 제거
       ),
       body: Padding(
-        padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.05),
+        padding: EdgeInsets.all(screenWidth * 0.02), // padding을 화면 너비의 2%로 설정
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            SizedBox(height: screenHeight * 0.02), // 상대 크기 설정
-            // 검색 필드
+            // 'ご利用店舗選択' 텍스트를 상단에 배치
+            Padding(
+              padding: EdgeInsets.only(top: screenHeight * 0.01), // 화면 높이의 1%로 상단 여백
+              child: Text(
+                'ご利用店舗選択', // AppBar에서 옮겨온 텍스트
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: screenWidth * 0.07, // 텍스트 크기 화면 너비의 7%
+                  fontWeight: FontWeight.normal,
+                ),
+              ),
+            ),
+            SizedBox(height: screenHeight * 0.02), // 추가적인 여백
+
             TextField(
               onChanged: (query) {
                 final trimmedQuery = query.trim();
@@ -58,7 +72,7 @@ class _UpdatePubIdScreenState extends ConsumerState<UpdatePubIdScreen> {
                 ),
               ),
             ),
-            SizedBox(height: screenHeight * 0.02),
+            SizedBox(height: screenHeight * 0.002),
             // 필터링된 매장 리스트
             Expanded(
               child: filteredStoreNames.isEmpty
@@ -68,22 +82,31 @@ class _UpdatePubIdScreenState extends ConsumerState<UpdatePubIdScreen> {
                         style: TextStyle(fontSize: screenWidth * 0.045, color: Colors.grey),
                       ),
                     )
-                  : ListView.separated(
+                  : ListView.builder(
                       itemCount: filteredStoreNames.length,
-                      separatorBuilder: (context, index) => Divider(
-                        color: Colors.grey[300],
-                        thickness: screenHeight * 0.001, // 상대 크기 설정
-                        height: screenHeight * 0.01, // 상대 크기 설정
-                      ),
                       itemBuilder: (context, index) {
                         final storeName = filteredStoreNames[index];
-                        return _buildStoreTile(
-                          context,
-                          viewModel,
-                          storeName,
-                          screenWidth,
-                          screenHeight,
-                          selectedStoreName,
+                        return Column(
+                          children: [
+                            Padding(
+                              padding: EdgeInsets.symmetric(horizontal: screenWidth * 0.04), // 왼쪽/오른쪽 패딩 추가
+                              child: _buildStoreTile(
+                                context,
+                                viewModel,
+                                storeName,
+                                screenWidth,
+                                screenHeight,
+                                selectedStoreName,
+                              ),
+                            ),
+                            Divider(
+                              color: Colors.grey[300],
+                              thickness: screenHeight * 0.001, // 상대 크기 설정
+                              height: screenHeight * 0.005, // 항목과 간격을 좁히기 위해 줄임
+                              indent: screenWidth * 0.04, // 왼쪽 padding과 맞추기
+                              endIndent: screenWidth * 0.04, // 오른쪽 padding과 맞추기
+                            ),
+                          ],
                         );
                       },
                     ),
@@ -103,34 +126,25 @@ class _UpdatePubIdScreenState extends ConsumerState<UpdatePubIdScreen> {
     double screenHeight,
     String? selectedStoreName,
   ) {
-    return Column(
-      children: [
-        ListTile(
-          contentPadding: EdgeInsets.symmetric(vertical: screenHeight * 0.015),
-          title: Text(
-            storeName,
-            style: TextStyle(
-              fontSize: screenWidth * 0.045,
-              color: storeName == selectedStoreName ? Colors.blue : Colors.black,
-              fontWeight: storeName == selectedStoreName ? FontWeight.bold : FontWeight.normal,
-            ),
-          ),
-          onTap: () async {
-            final isSuccess = await viewModel.updateSelectedStoreAndPubId(storeName);
-            if (isSuccess) {
-              ref.read(userAccountProvider.notifier).updatePubId(storeName);
-              Navigator.pop(context); // 성공 시 이전 화면으로 이동
-            } else {
-              _showSnackBar(context, '更新に失敗しました。'); // 실패 시 에러 메시지 표시
-            }
-          },
+    return ListTile(
+      contentPadding: EdgeInsets.symmetric(vertical: screenHeight * 0.007),
+      title: Text(
+        storeName,
+        style: TextStyle(
+          fontSize: screenWidth * 0.045,
+          color: storeName == selectedStoreName ? Colors.blue : Colors.black,
+          fontWeight: storeName == selectedStoreName ? FontWeight.bold : FontWeight.normal,
         ),
-        Divider(
-          color: Colors.grey[300],
-          thickness: screenHeight * 0.001, // 상대 크기 설정
-          height: screenHeight * 0.01, // 상대 크기 설정
-        ),
-      ],
+      ),
+      onTap: () async {
+        final isSuccess = await viewModel.updateSelectedStoreAndPubId(storeName);
+        if (isSuccess) {
+          ref.read(userAccountProvider.notifier).updatePubId(storeName);
+          Navigator.pop(context); // 성공 시 이전 화면으로 이동
+        } else {
+          _showSnackBar(context, '更新に失敗しました。'); // 실패 시 에러 메시지 표시
+        }
+      },
     );
   }
 

--- a/lib/view/tab/user/user_home_screen.dart
+++ b/lib/view/tab/user/user_home_screen.dart
@@ -9,7 +9,7 @@ import 'user_transfer_confirm_screen.dart'; // 유저 포인트 거래 확인 �
 import 'user_transaction_history_screen.dart';
 import '../event_home.dart';
 import 'user_account_screen.dart';
-import 'verify_password_screen.dart'; // 비밀번호 확인 화면 추가
+import '../verify_password_screen.dart'; // 비밀번호 확인 화면 추가
 import 'update_pubid_screen.dart';
 import '../privacy_policy_screen.dart';
 import '../terms_of_service_screen.dart';

--- a/lib/view/tab/verify_password_screen.dart
+++ b/lib/view/tab/verify_password_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../../viewModel/user_account_view_model.dart';
-import 'user_account_screen.dart';
+import 'user/user_account_screen.dart';
+import '../../services/auth_service.dart';
 
 class VerifyPasswordScreen extends ConsumerStatefulWidget {
   @override
@@ -164,6 +164,7 @@ class SubmitButtonSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final AuthService _authService = AuthService();
     return Center(
       child: ElevatedButton(
         onPressed: () async {
@@ -181,15 +182,15 @@ class SubmitButtonSection extends StatelessWidget {
           }
           
           // 비밀번호 인증 요청
-          final isValid = await ref
-              .read(userAccountProvider.notifier)
-              .validatePassword(password);
+          final isValid = await _authService.validatePassword(password);
 
           if (isValid) {
             // 성공 시 비밀번호 재설정 화면으로 이동
-            Navigator.pushReplacement(
-              context,
-              MaterialPageRoute(builder: (context) => UserAccountScreen()),
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('비밀번호 변경 이메일을 보냈습니다。'),
+                backgroundColor: Colors.green,
+              ),
             );
           } else {
             // 실패 시 에러 메시지 표시

--- a/lib/viewModel/owner_account_view_model.dart
+++ b/lib/viewModel/owner_account_view_model.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
+import '../model/owner_model.dart';
+import '../model/photo_upload_model.dart';
+import '../services/preferences_manager.dart';
+
+class OwnerAccountViewModel extends StateNotifier<AsyncValue<Map<String, dynamic>>> {
+  OwnerAccountViewModel() : super(const AsyncValue.loading());
+
+  /// 두 상태를 관리하기 위해 별도 변수 사용
+  AsyncValue<Owner> ownerState = const AsyncValue.loading();
+  AsyncValue<PhotoUpload> pubInfoState = const AsyncValue.loading();
+
+  Future<void> fetchOwnerData() async {
+    ownerState = const AsyncValue.loading();
+    state = _combineStates(); // 상태를 업데이트
+
+    try {
+      // 1. PreferencesManager에서 이메일 가져오기
+      final email = await PreferencesManager.instance.getEmail();
+
+      if (email == null) {
+        throw Exception('이메일이 설정되지 않았습니다.');
+      }
+
+      // 2. Firestore에서 이메일로 사용자 문서 조회
+      final querySnapshot = await FirebaseFirestore.instance
+          .collection('owners')
+          .where('email', isEqualTo: email)
+          .get();
+
+      if (querySnapshot.docs.isEmpty) {
+        throw Exception('사용자 정보를 찾을 수 없습니다.');
+      }
+
+      // 3. Firestore 데이터를 Owner 모델로 변환
+      final ownerData = querySnapshot.docs.first.data();
+      final owner = Owner.fromJson(ownerData);
+
+      ownerState = AsyncValue.data(owner);
+    } catch (e, stackTrace) {
+      ownerState = AsyncValue.error(e, stackTrace);
+    } finally {
+      state = _combineStates(); // 최종 상태 업데이트
+    }
+  }
+
+  Future<void> fetchPubInfoData() async {
+    pubInfoState = const AsyncValue.loading();
+    state = _combineStates(); // 상태를 업데이트
+
+    try {
+      // 1. PreferencesManager에서 이메일 가져오기
+      final email = await PreferencesManager.instance.getEmail();
+
+      if (email == null) {
+        throw Exception('이메일이 설정되지 않았습니다.');
+      }
+
+      // 2. Firestore에서 PubInfos 문서 조회
+      final querySnapshot = await FirebaseFirestore.instance
+          .collection('PubInfos')
+          .where('ownerId', isEqualTo: email)
+          .get();
+
+      if (querySnapshot.docs.isEmpty) {
+        throw Exception('PubInfos 데이터를 찾을 수 없습니다.');
+      }
+
+      // 3. Firestore 데이터를 PhotoUpload 모델로 변환
+      final pubInfoData = querySnapshot.docs.first.data();
+      final photoUpload = PhotoUpload.fromJson(pubInfoData);
+
+      pubInfoState = AsyncValue.data(photoUpload);
+    } catch (e, stackTrace) {
+      pubInfoState = AsyncValue.error(e, stackTrace);
+    } finally {
+      state = _combineStates(); // 최종 상태 업데이트
+    }
+  }
+
+  /// 두 상태를 병합하여 하나의 상태로 반환
+  AsyncValue<Map<String, dynamic>> _combineStates() {
+    final owner = ownerState;
+    final pubInfo = pubInfoState;
+
+    if (owner.isLoading || pubInfo.isLoading) {
+      return const AsyncValue.loading();
+    }
+
+    if (owner.hasError) {
+      return AsyncValue.error(owner.error!, owner.stackTrace ?? StackTrace.current);
+    }
+
+    if (pubInfo.hasError) {
+      return AsyncValue.error(pubInfo.error!, pubInfo.stackTrace ?? StackTrace.current);
+    }
+
+
+    if (owner.hasValue && pubInfo.hasValue) {
+      return AsyncValue.data({
+        'owner': owner.value!,
+        'pubInfo': pubInfo.value!,
+      });
+    }
+
+    return const AsyncValue.loading();
+  }
+}
+
+final ownerAccountProvider =
+    StateNotifierProvider<OwnerAccountViewModel, AsyncValue<Map<String, dynamic>>>((ref) {
+  final viewModel = OwnerAccountViewModel();
+  viewModel.fetchOwnerData(); // 초기화 시 Owner 데이터 조회
+  viewModel.fetchPubInfoData(); // 초기화 시 PubInfo 데이터 조회
+  return viewModel;
+});

--- a/lib/viewModel/owner_sign_up_view_model.dart
+++ b/lib/viewModel/owner_sign_up_view_model.dart
@@ -256,20 +256,24 @@ class OwnerSignUpViewModel extends StateNotifier<OwnerSignUpState> {
         // 문서 ID 가져오기
         final docId = querySnapshot.docs.first.id;
 
-        // 업데이트할 데이터 준비
+        // 업데이트할 데이터 준비 (null 값은 제외)
         final updatedData = {
-          'storeName': state.storeName,
-          'zipCode': state.zipCode,
-          'state': state.state,
-          'city': state.city,
-          'address': state.address,
-          'building': state.building?.isNotEmpty == true ? state.building : null,
+          if (state.storeName != null && state.storeName!.isNotEmpty) 'storeName': state.storeName,
+          if (state.zipCode != null && state.zipCode!.isNotEmpty) 'zipCode': state.zipCode,
+          if (state.state != null && state.state!.isNotEmpty) 'state': state.state,
+          if (state.city != null && state.city!.isNotEmpty) 'city': state.city,
+          if (state.address != null && state.address!.isNotEmpty) 'address': state.address,
+          if (state.building != null && state.building!.isNotEmpty) 'building': state.building,
         };
 
-        // 문서 업데이트
-        await _firestore.collection('owners').doc(docId).update(updatedData);
-
-        debugPrint('Owner 정보가 성공적으로 업데이트되었습니다.');
+        if (updatedData.isNotEmpty) {
+          // 문서 업데이트
+          await _firestore.collection('owners').doc(docId).update(updatedData);
+          debugPrint('Owner 정보가 성공적으로 업데이트되었습니다.');
+        } else {
+          debugPrint('업데이트할 데이터가 없습니다.');
+          state = state.copyWith(signUpError: '업데이트할 데이터가 없습니다。');
+        }
       } else {
         debugPrint('해당 이메일로 등록된 문서를 찾을 수 없습니다.');
         state = state.copyWith(signUpError: '등록된 이메일을 찾을 수 없습니다。');

--- a/lib/viewModel/owner_sign_up_view_model.dart
+++ b/lib/viewModel/owner_sign_up_view_model.dart
@@ -1,4 +1,3 @@
-// owner_sign_up_view_model.dart
 import 'dart:math';
 import 'package:flutter/foundation.dart'; // debugPrint 사용을 위한 패키지
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,6 +6,7 @@ import '../model/owner_model.dart';
 import '../services/auth_service.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../services/preferences_manager.dart';
 
 class OwnerSignUpViewModel extends StateNotifier<OwnerSignUpState> {
   final AuthService _authService;
@@ -238,6 +238,48 @@ class OwnerSignUpViewModel extends StateNotifier<OwnerSignUpState> {
 
   void resetResendCodeError() {
     state = state.copyWith(resendCodeError: null);
+  }
+
+  // owners 컬렉션의 문서를 업데이트하는 메서드
+  Future<void> updateOwnerInfo() async {
+    try {
+      // 현재 사용자 이메일 가져오기
+      final email = await PreferencesManager.instance.getEmail();
+
+      // email 필드로 Firestore에서 문서를 검색
+      final querySnapshot = await _firestore
+          .collection('owners')
+          .where('email', isEqualTo: email)
+          .get();
+
+      if (querySnapshot.docs.isNotEmpty) {
+        // 문서 ID 가져오기
+        final docId = querySnapshot.docs.first.id;
+
+        // 업데이트할 데이터 준비
+        final updatedData = {
+          'storeName': state.storeName,
+          'zipCode': state.zipCode,
+          'state': state.state,
+          'city': state.city,
+          'address': state.address,
+          'building': state.building?.isNotEmpty == true ? state.building : null,
+        };
+
+        // 문서 업데이트
+        await _firestore.collection('owners').doc(docId).update(updatedData);
+
+        debugPrint('Owner 정보가 성공적으로 업데이트되었습니다.');
+      } else {
+        debugPrint('해당 이메일로 등록된 문서를 찾을 수 없습니다.');
+        state = state.copyWith(signUpError: '등록된 이메일을 찾을 수 없습니다。');
+      }
+    } catch (e) {
+      debugPrint('오너 정보 업데이트 중 오류 발생: $e');
+      state = state.copyWith(
+        signUpError: '정보 업데이트 중 오류가 발생했습니다。',
+      );
+    }
   }
 }
 

--- a/lib/viewModel/user_account_view_model.dart
+++ b/lib/viewModel/user_account_view_model.dart
@@ -39,62 +39,6 @@ class UserAccountViewModel extends StateNotifier<AsyncValue<User>> {
     }
   }
 
-  //현재 사용자 이메일로 비밀번호 재설정 이메일을 보냅니다.
-  Future<void> sendPasswordResetEmail() async {
-    try {
-      final user = state.value; // 현재 상태에서 사용자 데이터를 가져옵니다.
-
-      if (user == null || user.email.isEmpty) {
-        throw Exception('사용자의 이메일 정보를 확인할 수 없습니다.');
-      }
-
-      // Firebase Authentication을 사용하여 비밀번호 재설정 이메일 전송
-      await firebase_auth.FirebaseAuth.instance
-          .sendPasswordResetEmail(email: user.email);
-
-      print('비밀번호 재설정 이메일이 발송되었습니다.'); // 성공 로그
-    } catch (e) {
-      print('비밀번호 재설정 이메일 발송 중 오류가 발생했습니다: $e');
-      throw Exception('비밀번호 재설정 이메일 발송 실패: $e'); // 실패 시 예외 발생
-    }
-  }
-  
-  //사용자 패스워드를 재인증합니다.
-  Future<bool> validatePassword(String password) async {
-    try {
-      final user = state.value; // 현재 상태에서 사용자 데이터를 가져옵니다.
-
-      if (user == null || user.email.isEmpty) {
-        throw Exception('사용자의 이메일 정보를 확인할 수 없습니다.');
-      }
-
-      // 1. 현재 로그인된 사용자 가져오기
-      final currentUser = firebase_auth.FirebaseAuth.instance.currentUser;
-
-      if (currentUser == null) {
-        throw Exception('현재 로그인된 사용자를 찾을 수 없습니다.');
-      }
-
-      // 2. 이메일과 비밀번호로 자격 증명 생성
-      final credential = firebase_auth.EmailAuthProvider.credential(
-        email: user.email,
-        password: password,
-      );
-
-      // 3. Firebase Authentication에서 재인증
-      await currentUser.reauthenticateWithCredential(credential);
-
-      // 4. 비밀번호 재설정 이메일 전송
-      await sendPasswordResetEmail();
-
-      print('비밀번호 인증 성공'); // 성공 로그
-      return true;
-    } catch (e) {
-      print('비밀번호 인증 실패: $e'); // 실패 로그
-      return false;
-    }
-  }
-
   void updatePubId(String newPubId) {
     final user = state.value; // 현재 상태에서 사용자 데이터를 가져옵니다.
     if (user != null) {


### PR DESCRIPTION
lib/services/auth_service.dart: validatePassword 비밀번호 인증 및 sendPasswordResetEmail 비밀번호 재설정 메일을 보내는 함수를
재사용 하기 위해 이동하였습니다.

lib/view/tab/owner/owner_account_screen.dart: user_account_tab을 변형하여 구현하였습니다.

lib/view/tab/owner/owner_home_screen.dart: account tab 경로 추가

lib/view/tab/user/update_pubid_screen.dart: UI 수정 로직은 변경하지 않았습니다.

lib/view/tab/owner/owner_signup_update_screen.dart: 사용자의 가게 정보를 변경하는 화면입니다. 입력된값만 firestore에 업데이트되도록 구현하였습니다.

lib/view/tab/owner/photo_update_screen.dart: 가게 사진을 변경하는 화면입니다. owner_signup_update_screen와는 다르게 모든 사진을 업데이트하도록 구현하였습니다. 기존 사진은 삭제하고 다시 재업로드 합니다.

lib/view/tab/owner/point_management_screen.dart: UI를 수정하였습니다.

lib/view/tab/user/user_home_screen.dart: 경로 변경

lib/view/tab/verify_password_screen.dart: owner account 및 user account에서 사용할 수 있도록 경로를 변경하였습니다.

lib/viewModel/owner_account_view_model.dart: owners 컬렉션의 정보와 pubInfos 컬렉션의 정보를 합하여 state를 만들고 사용하였습니다.

lib/viewModel/owner_sign_up_view_model.dart: 기존 회원가입 viewmodel에 owners 컬렉션을 update하는 코드를 추가하였습니다.
입력되지 않은 필드는 업데이트되지 않도록 구현하였습니다.

lib/viewModel/photo_upload_view_model.dart: 사진을 update하는 코드를 추가하였습니다. 기존 사진을 지우고 다시 업로드 하도록 구현하였습니다.

lib/viewModel/user_account_view_model.dart: 재사용을 위해 validatePassword 비밀번호 인증 및 sendPasswordResetEmail 비밀번호 재설정 메일을 보내는 함수를 lib/services/auth_service.dart로 이동하였습니다.